### PR TITLE
Bug 20664: Optimize retrieval of biblio and item data

### DIFF
--- a/C4/Items.pm
+++ b/C4/Items.pm
@@ -1555,7 +1555,7 @@ sub GetMarcItemFields {
     ITEMLOOP: foreach my $item (@$items) {
 
         # Check itemnumbers
-        next if ( @$itemnumbers && !any { $_ == $item->itemnumber } @$itemnumbers );
+        next if ( @$itemnumbers && !any { $_ == $item->{itemnumber} } @$itemnumbers );
 
         # Check hiding rules
         if ( defined $hidingrules ) {


### PR DESCRIPTION
Optimizes embedding of item data in MARC and fixes several bottlenecks encountered while profiling OAI-PMH and exporting of records. There are three ways this is accomplished:

1.) Use state variables to hold prepared SQL statements so that the preparation is done only once.
2.) Create optimized method for fetching item fields for MARC embedding.
3.) Use the cache service more and where repeated calls are made.

Test plan:

1.) Before applying the patch, time an export_records.pl run for a set of biblios that also have items. Run it a couple of times to account for initial slowness and possible fluctuations. For example:

time misc/export_records.pl --record-type bibs --starting_biblionumber 960000 --ending_biblionumber 965000 --format xml --filename unoptimized.xml

2.) Apply the patch.

3.) Time the export process again with a different output file:

time misc/export_records.pl --record-type bibs --starting_biblionumber 960000 --ending_biblionumber 965000 --format xml --filename optimized.xml

4.) Verify that the optimized process is faster.

5.) Compare the resulting export files to make sure they're identical: