### PR TITLE
KD-3198: Remove duplicate keys

### DIFF
--- a/api/v1/swagger/paths/accountlines.json
+++ b/api/v1/swagger/paths/accountlines.json
@@ -67,9 +67,6 @@
       "x-mojo-to": "Accountline#edit",
       "operationId": "editAccountlines",
       "tags": ["accountlines"],
-      "produces": [
-        "application/json"
-      ],
       "parameters": [
         { "$ref": "../parameters.json#/accountlinesIdPathParam" },
         {
@@ -148,9 +145,6 @@
       "x-mojo-to": "Accountline#pay",
       "operationId": "payAccountlines",
       "tags": ["accountlines"],
-      "produces": [
-        "application/json"
-      ],
       "parameters": [
         { "$ref": "../parameters.json#/accountlinesIdPathParam" },
         {

--- a/api/v1/swagger/paths/patrons.json
+++ b/api/v1/swagger/paths/patrons.json
@@ -1015,9 +1015,6 @@
       "x-mojo-to": "Patron#pay",
       "operationId": "payForPatron",
       "tags": ["accountlines"],
-      "produces": [
-        "application/json"
-      ],
       "parameters": [
         { "$ref": "../parameters.json#/borrowernumberPathParam" },
         {


### PR DESCRIPTION
The "produces" key was defined two times in these cases. This removes
the second definitions.

Test plan:

1. Run "prove t/db_dependent/api/v1/swagger/definitions.t" and check that
error "Duplicate keys not allowed" has disappeared.