### PR TITLE
KD-3225: Cherry-pick fixes from community master branch

### DIFF
--- a/debian/templates/apache-shared-intranet.conf
+++ b/debian/templates/apache-shared-intranet.conf
@@ -17,8 +17,8 @@ RewriteRule (.+) $1?%1%2 [N,R,NE]
 RewriteRule ^/bib/([^\/]*)/?$ /cgi-bin/koha/detail\.pl?bib=$1 [PT]
 RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
 RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
-RewriteRule ^(.*)_(.*).js$ $1.js [N,L]
-RewriteRule ^(.*)_(.*).css$ $1.css [N,L]
+RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [N,L]
+RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [N,L]
 
 Alias "/api" "/usr/share/koha/api"
 <Directory "/usr/share/koha/api">

--- a/debian/templates/apache-shared-intranet.conf
+++ b/debian/templates/apache-shared-intranet.conf
@@ -17,8 +17,7 @@ RewriteRule (.+) $1?%1%2 [N,R,NE]
 RewriteRule ^/bib/([^\/]*)/?$ /cgi-bin/koha/detail\.pl?bib=$1 [PT]
 RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
 RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
-RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [L]
-RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [L]
+RewriteRule ^(.*)_[0-9]{2}\.[0-9]{7}\.(js|css)$ $1.$2 [L]
 
 Alias "/api" "/usr/share/koha/api"
 <Directory "/usr/share/koha/api">

--- a/debian/templates/apache-shared-intranet.conf
+++ b/debian/templates/apache-shared-intranet.conf
@@ -17,8 +17,8 @@ RewriteRule (.+) $1?%1%2 [N,R,NE]
 RewriteRule ^/bib/([^\/]*)/?$ /cgi-bin/koha/detail\.pl?bib=$1 [PT]
 RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
 RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
-RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [N,L]
-RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [N,L]
+RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [L]
+RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [L]
 
 Alias "/api" "/usr/share/koha/api"
 <Directory "/usr/share/koha/api">

--- a/debian/templates/apache-shared-opac.conf
+++ b/debian/templates/apache-shared-opac.conf
@@ -17,8 +17,8 @@ RewriteRule (.+) $1?%1%2 [N,R,NE]
 RewriteRule ^/bib/([^\/]*)/?$ /cgi-bin/koha/opac-detail\.pl?bib=$1 [PT]
 RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
 RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
-RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [N,L]
-RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [N,L]
+RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [L]
+RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [L]
 
 <IfVersion >= 2.4>
     AliasMatch "^/sitemap(.*)" "/var/lib/koha/${instance}/sitemap/sitemap$1"

--- a/debian/templates/apache-shared-opac.conf
+++ b/debian/templates/apache-shared-opac.conf
@@ -17,8 +17,7 @@ RewriteRule (.+) $1?%1%2 [N,R,NE]
 RewriteRule ^/bib/([^\/]*)/?$ /cgi-bin/koha/opac-detail\.pl?bib=$1 [PT]
 RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
 RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
-RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [L]
-RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [L]
+RewriteRule ^(.*)_[0-9]{2}\.[0-9]{7}\.(js|css)$ $1.$2 [L]
 
 <IfVersion >= 2.4>
     AliasMatch "^/sitemap(.*)" "/var/lib/koha/${instance}/sitemap/sitemap$1"

--- a/debian/templates/apache-shared-opac.conf
+++ b/debian/templates/apache-shared-opac.conf
@@ -17,8 +17,8 @@ RewriteRule (.+) $1?%1%2 [N,R,NE]
 RewriteRule ^/bib/([^\/]*)/?$ /cgi-bin/koha/opac-detail\.pl?bib=$1 [PT]
 RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
 RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
-RewriteRule ^(.*)_(.*).js$ $1.js [N,L]
-RewriteRule ^(.*)_(.*).css$ $1.css [N,L]
+RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [N,L]
+RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [N,L]
 
 <IfVersion >= 2.4>
     AliasMatch "^/sitemap(.*)" "/var/lib/koha/${instance}/sitemap/sitemap$1"

--- a/etc/koha-httpd.conf
+++ b/etc/koha-httpd.conf
@@ -151,8 +151,8 @@
      RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
      RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
      RewriteRule ^/intranet-tmpl/lib/tiny_mce/? - [L,NC]
-     RewriteRule ^(.*)_(.*).js$ $1.js [N,L]
-     RewriteRule ^(.*)_(.*).css$ $1.css [N,L]
+     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [N,L]
+     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [N,L]
 
      # REST API configuration
      Alias "/api" "__API_CGI_DIR__"
@@ -320,8 +320,8 @@
      RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
      RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
      RewriteRule ^/intranet-tmpl/lib/tiny_mce/? - [L,NC]
-     RewriteRule ^(.*)_(.*).js$ $1.js [N,L]
-     RewriteRule ^(.*)_(.*).css$ $1.css [N,L]
+     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [N,L]
+     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [N,L]
 
      # REST API configuration
      Alias "/api" "__API_CGI_DIR__"

--- a/etc/koha-httpd.conf
+++ b/etc/koha-httpd.conf
@@ -151,8 +151,7 @@
      RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
      RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
      RewriteRule ^/intranet-tmpl/lib/tiny_mce/? - [L,NC]
-     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [L]
-     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [L]
+     RewriteRule ^(.*)_[0-9]{2}\.[0-9]{7}\.(js|css)$ $1.$2 [L]
 
      # REST API configuration
      Alias "/api" "__API_CGI_DIR__"
@@ -320,8 +319,7 @@
      RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
      RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
      RewriteRule ^/intranet-tmpl/lib/tiny_mce/? - [L,NC]
-     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [L]
-     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [L]
+     RewriteRule ^(.*)_[0-9]{2}\.[0-9]{7}\.(js|css)$ $1.$2 [L]
 
      # REST API configuration
      Alias "/api" "__API_CGI_DIR__"

--- a/etc/koha-httpd.conf
+++ b/etc/koha-httpd.conf
@@ -151,8 +151,8 @@
      RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
      RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
      RewriteRule ^/intranet-tmpl/lib/tiny_mce/? - [L,NC]
-     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [N,L]
-     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [N,L]
+     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [L]
+     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [L]
 
      # REST API configuration
      Alias "/api" "__API_CGI_DIR__"
@@ -320,8 +320,8 @@
      RewriteRule ^/isbn/([^\/]*)/?$ /search?q=isbn:$1 [PT]
      RewriteRule ^/issn/([^\/]*)/?$ /search?q=issn:$1 [PT]
      RewriteRule ^/intranet-tmpl/lib/tiny_mce/? - [L,NC]
-     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [N,L]
-     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [N,L]
+     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].js$ $1.js [L]
+     RewriteRule ^(.*)_[0-9][0-9]\.[0-9][0-9][0-9][0-9][0-9][0-9][0-9].css$ $1.css [L]
 
      # REST API configuration
      Alias "/api" "__API_CGI_DIR__"


### PR DESCRIPTION
Some of the Javascript and CSS files with _ in their name won't load without these patches from the Koha community master branch. 