### PR TITLE
KD-3280: Include holdings in OAI-PMH

### DIFF
--- a/C4/Biblio.pm
+++ b/C4/Biblio.pm
@@ -374,6 +374,26 @@ sub _strip_item_fields {
     }
 }
 
+=head2 _strip_holdings_fields
+
+  _strip_holdings_fields($record)
+
+Utility routine to remove holdings tags from a
+MARC bib.
+
+=cut
+
+sub _strip_holdings_fields {
+    my $record = shift;
+    my $frameworkcode = shift;
+
+    my ( $holdingstag ) = GetMarcFromKohaField( "holdings.holdingbranch" );
+
+    foreach my $field ( $record->field($holdingstag) ) {
+        $record->delete_field($field);
+    }
+}
+
 =head2 DelBiblio
 
   my $error = &DelBiblio($biblionumber);
@@ -3553,6 +3573,16 @@ sub EmbedItemsInMarcBiblio {
     }
 
     $itemnumbers = [] unless defined $itemnumbers;
+
+    if ( C4::Context->preference('SummaryHoldings') && !@$itemnumbers ) {
+        _strip_holdings_fields($marc);
+
+        require C4::Holdings;
+
+        my $holdings_fields = C4::Holdings::GetMarcHoldingsFields( $biblionumber );
+
+        $marc->append_fields(@$holdings_fields) if ( @$holdings_fields );
+    }
 
     _strip_item_fields($marc);
 

--- a/Koha/OAI/Server/Repository.pm
+++ b/Koha/OAI/Server/Repository.pm
@@ -95,6 +95,7 @@ mode. A configuration file koha-oai.conf can look like that:
       xsl_file: /usr/local/koha/koha-tmpl/intranet-tmpl/xslt/UNIMARCslim2OAIDC.xsl
 
 Note the 'include_items' parameter which is the only mean to return item-level info.
+If summary holdings are enabled, 'include_items' includes their location information too.
 
 =cut
 


### PR DESCRIPTION
Include holdings fields in MARC records returned via OAI-PMH if include_items is enabled in oai conf file and SummaryHoldings is enabled in preferences.