### PR TITLE
Bug-2606: (squashable) Check if reservesallowed is defined before usage

### DIFF
--- a/circ/pendingreserves.pl
+++ b/circ/pendingreserves.pl
@@ -223,7 +223,7 @@ sub check_issuingrules {
                 reserve_level => $item->reserve_level,
             }
         );
-        if ($issuing_rule->reservesallowed && $issuing_rule->reservesallowed != 0) {
+        if (defined $issuing_rule->reservesallowed && $issuing_rule->reservesallowed != 0) {
             my $colid = GetItemsCollection($itemnumber);
 
             if ($colid) {


### PR DESCRIPTION
The "defined" check was left out incorrectly in the original
commit. This fixes following error:

[ERROR] Can't call method "reservesallowed" on an undefined value at
/home/koha/Koha/circ/pendingreserves.pl line 226.