### PR TITLE
Bug-2606: (squashable) Add missing curly braces

### DIFF
--- a/circ/pendingreserves.pl
+++ b/circ/pendingreserves.pl
@@ -223,7 +223,7 @@ sub check_issuingrules {
                 reserve_level => $item->reserve_level,
             }
         );
-        if (defined $issuing_rule->reservesallowed && $issuing_rule->reservesallowed != 0) {
+        if (defined $issuing_rule->{reservesallowed} && $issuing_rule->reservesallowed != 0) {
             my $colid = GetItemsCollection($itemnumber);
 
             if ($colid) {


### PR DESCRIPTION
Without the curly braces the reservesallowed is treated as a method.