### PR TITLE
Bug 14698 - AtomicUpdater - Fix executing .sql-files. C4::Installer w…

### DIFF
--- a/Koha/AtomicUpdater.pm
+++ b/Koha/AtomicUpdater.pm
@@ -26,6 +26,8 @@ use Git;
 use YAML::XS;
 use File::Slurp;
 
+use C4::Installer;
+
 use Koha::Database;
 use Koha::Cache;
 use Koha::AtomicUpdate;


### PR DESCRIPTION
…as not use'd

A priori:

koha@koha-ci-jyu:~/Koha$ perl installer/data/mysql/atomicupdate.pl -s installer/data/mysql/atomicupdate/bug_20447-add_holdings_tables.sql
Can't locate object method "new" via package "C4::Installer" (perhaps you forgot to load "C4::Installer"?) at /home/koha/Koha/Koha/AtomicUpdater.pm line 256.

A posteriori:

nothing is printed, atomicupdate completed succesfully.