### PR TITLE
Bug-2606: (squashable) fix errors in check_issuingrules

### DIFF
--- a/circ/pendingreserves.pl
+++ b/circ/pendingreserves.pl
@@ -212,7 +212,7 @@ sub check_issuingrules {
             next;
         }
         my $issuing_rule = Koha::IssuingRules->get_effective_issuing_rule(
-            {   categorycode => $borrower->{categorycode},
+            {   categorycode => $borrower->categorycode,
                 itemtype     => $item->itype,
                 branchcode   => $data->{l_branch},
                 ccode        => $item->ccode,
@@ -223,7 +223,7 @@ sub check_issuingrules {
                 reserve_level => $item->reserve_level,
             }
         );
-        if (defined $issuing_rule->{reservesallowed} && $issuing_rule->reservesallowed != 0) {
+        if (defined $issuing_rule && $issuing_rule->reservesallowed != 0) {
             my $colid = GetItemsCollection($itemnumber);
 
             if ($colid) {


### PR DESCRIPTION
The Patron object needs to be accessed with method or otherwise the
value will be undef. We also should check if the issuing_rule is
defined instead of checking $issuing_rule->{reservesallowed} because
$issuing_rule->{reservesallowed} will always be undefined because
issuing_rule values need to be accessed with methods.