### PR TITLE
Bug 16826: (squashable) Don't show borrowernumber in availabilities e…

### DIFF
--- a/Koha/Item/Availability.pm
+++ b/Koha/Item/Availability.pm
@@ -152,6 +152,11 @@ sub swaggerize {
         $availability->{'notes'} = $notes;
     }
     if (keys %{$unavailabilities} > 0) {
+        # Don't reveal borrowernumber through REST API.
+        foreach my $key (keys %{$unavailabilities}) {
+            delete $unavailabilities->{$key}{'borrowernumber'};
+        }
+
         $availability->{'unavailabilities'} = $unavailabilities;
     }
 

--- a/api/v1/swagger/definitions/availability/reason.json
+++ b/api/v1/swagger/definitions/availability/reason.json
@@ -177,9 +177,6 @@
       "description": "Item is checked out to a patron.",
       "type": "object",
       "properties": {
-        "borrowernumber": {
-          "type": ["integer", "null"]
-        },
         "date_due": {
           "type": ["string", "null"],
           "format": "date-time"
@@ -213,9 +210,6 @@
       "description": "Someone has placed a hold on this item.",
       "type": "object",
       "properties": {
-        "borrowernumber": {
-          "$ref": "../../x-primitives.json#/borrowernumber"
-        },
         "status": {
           "type": ["string", "null"]
         },


### PR DESCRIPTION
…ndpoint

If an item is listed as unavailable in the endpoint
/api/v1/availability/biblio/search?biblionumber=xxxx it will show the
borrowernumber. If the borrowernumber is ever connected to a patron this
could leak some of the reserve or loan history for the patron.

To test:
 1. find a biblionumber that has a checked out item and go to
the above mentioned url to see that borrowernumber is displayed.
 2. Apply patch and see the borrowernumber disappears and rest of the
data is intact