### PR TITLE
KD-1939: (squashable) check if $issuing_rules variable is defined

### DIFF
--- a/C4/Reserves.pm
+++ b/C4/Reserves.pm
@@ -899,7 +899,7 @@ sub CheckReserves {
         my $priority = 10000000;
         foreach my $res (@reserves) {
             my $issuing_rules = CheckIssuingRules($itemnumber, $res->{'borrowernumber'});
-            return if ($issuing_rules->reservesallowed == 0);
+            return if (!defined $issuing_rules || $issuing_rules->reservesallowed == 0);
             if ( $res->{'itemnumber'} == $itemnumber && $res->{'priority'} == 0) {
                 return ( "Waiting", $res, \@reserves ); # Found it
             } else {


### PR DESCRIPTION
This prevents error happening because $issuing_rules->reservesallowed
would be undefined->reservesallowed in case there is no issuing rule.