### PR TITLE
Bug 12586: (follow-up) add missing C4::Search import

### DIFF
--- a/C4/Matcher.pm
+++ b/C4/Matcher.pm
@@ -21,6 +21,8 @@ use Modern::Perl;
 
 use MARC::Record;
 
+use C4::Search;
+
 use Koha::SearchEngine;
 use Koha::SearchEngine::Search;
 use Koha::Util::Normalize qw/legacy_default remove_spaces upper_case lower_case/;


### PR DESCRIPTION
The commit b4392018bc1f9bf6a2f7dfe70b488856ad3a3897 (Bug 12478: make
things using SimpleSearch use the new version) removed the said
import. We still need it as C4::Search::new_record_from_zebra is called.

If you try to add a new record through records REST endpoint the error is visible. With Koha's own deduplicator (cgi-bin/koha/cataloguing/deduplicator.pl) the issue won't show up probably because some other code that is calling the get_matches function already has done the import.