### PR TITLE
Bug 21480: misc/translator/translate does not work with perl 5.26

### DIFF
--- a/misc/translator/text-extract.pl
+++ b/misc/translator/text-extract.pl
@@ -1,6 +1,10 @@
 #!/usr/bin/perl
 #use strict;
 #use warnings; FIXME - Bug 2505
+
+use FindBin;
+use lib $FindBin::Bin;
+
 use HTML::Tree;
 use Getopt::Std;
 getopt("f:");

--- a/misc/translator/text-extract2.pl
+++ b/misc/translator/text-extract2.pl
@@ -14,6 +14,9 @@
 # --> This will be relatively major rework, and requires corresponding
 # rework in tmpl_process.pl
 
+use FindBin;
+use lib $FindBin::Bin;
+
 use strict;
 #use warnings; FIXME - Bug 2505
 use Getopt::Long;

--- a/misc/translator/tmpl_process3.pl
+++ b/misc/translator/tmpl_process3.pl
@@ -4,6 +4,9 @@
 # Parts copyright 2003-2004 Jerome Vizcaino
 # Parts copyright 2004 Ambrose Li
 
+use FindBin;
+use lib $FindBin::Bin;
+
 =head1 NAME
 
 tmpl_process3.pl - Alternative version of tmpl_process.pl

--- a/misc/translator/translate
+++ b/misc/translator/translate
@@ -19,6 +19,9 @@
 
 package Main;
 
+use FindBin;
+use lib $FindBin::Bin;
+
 use strict;
 use warnings;
 

--- a/misc/translator/xgettext.pl
+++ b/misc/translator/xgettext.pl
@@ -6,6 +6,9 @@ xgettext.pl - xgettext(1)-like interface for .tt strings extraction
 
 =cut
 
+use FindBin;
+use lib $FindBin::Bin;
+
 use strict;
 use warnings;
 use Getopt::Long;


### PR DESCRIPTION
Perl 5.26 (or earlier) introduced a security feature, where implicitly
including the program directory as a Perl library directory no longer
happens (perl -I. ).

This causes translate to fail because it cannot find the *.pm -files in
it's own directory.

This patch adds the familiar mantra
    use lib $FindBin::Bin;
to the relevant scripts.

To test:

1. Install Ubuntu18.04 or something else with Perl 5.26
2. Install Koha (we use the dev-install)
3. cd $KOHA_PATH/misc/translator/
4. perl translate create fi-FI
5. Observe problems with missing modules.

Signed-off-by: Julian Maurice <julian.maurice@biblibre.com>

Signed-off-by: Jonathan Druart <jonathan.druart@bugs.koha-community.org>
Cannot recreate the issue right now but the changes make sense.