### PR TITLE
Make Elasticsearch settings configurable

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -472,6 +472,18 @@ URL of your Hetula server.
 
 Name of the organization that you use with Hetula.
 
+=item ELASTICSEARCH_INDEX_CONFIG
+
+Elasticsearch default index settings config file.
+
+=item ELASTICSEARCH_FIELD_CONFIG
+
+Elasticsearch default field settings config file.
+
+=item ELASTICSEARCH_INDEX_MAPPINGS
+
+Elasticsearch index mapping settings config file.
+
 =back
 
 =cut
@@ -517,6 +529,9 @@ my %config_defaults = (
   'USE_ELASTICSEARCH'     => 'no',
   'ELASTICSEARCH_SERVERS' => '',
   'ELASTICSEARCH_INDEX'  => 'koha',
+  'ELASTICSEARCH_INDEX_CONFIG'  => '',
+  'ELASTICSEARCH_FIELD_CONFIG'  => '',
+  'ELASTICSEARCH_INDEX_MAPPINGS'  => '',
   'FONT_DIR'          => '/usr/share/fonts/truetype/ttf-dejavu'
 );
 
@@ -1300,6 +1315,17 @@ sharing the same Elasticsearch-cluster
 
 Elasticsearch index?);
       $config{'ELASTICSEARCH_INDEX'} = _get_value('ELASTICSEARCH_INDEX', $msg, $defaults->{'ELASTICSEARCH_INDEX'}, $valid_values, $install_log_values);
+
+      $msg = q(
+Elasticsearch index config file location?);
+      $config{'ELASTICSEARCH_INDEX_CONFIG'} = _get_value('ELASTICSEARCH_INDEX_CONFIG', $msg, $defaults->{'ELASTICSEARCH_INDEX_CONFIG'}, $valid_values, $install_log_values);
+      $msg = q(
+Elasticsearch field config file location?);
+      $config{'ELASTICSEARCH_FIELD_CONFIG'} = _get_value('ELASTICSEARCH_FIELD_CONFIG', $msg, $defaults->{'ELASTICSEARCH_FIELD_CONFIG'}, $valid_values, $install_log_values);
+      $msg = q(
+Elasticsearch mappings config file location?);
+      $config{'ELASTICSEARCH_INDEX_MAPPINGS'} = _get_value('ELASTICSEARCH_INDEX_MAPPINGS', $msg, $defaults->{'ELASTICSEARCH_INDEX_MAPPINGS'}, $valid_values, $install_log_values);
+
   }
 
   $msg = q(

--- a/etc/koha-conf.xml
+++ b/etc/koha-conf.xml
@@ -161,16 +161,16 @@ __PAZPAR2_TOGGLE_XML_POST__
      <server>__ELASTICSEARCH_SERVERS__</server>      <!-- may be repeated to include all servers on your cluster -->
      <index_name>__ELASTICSEARCH_INDEX__</index_name>  <!-- should be unique amongst all the indices on your cluster. _biblios and _authorities will be appended. -->
  </elasticsearch>
- <!-- Uncomment the following line if you want to override the Elasticsearch default index settings -->
- <!-- <elasticsearch_index_config>__KOHA_CONF_DIR__/searchengine/elasticsearch/index_config.yaml</elasticsearch_index_config> -->
- <!-- Uncomment the following line if you want to override the Elasticsearch default field settings -->
- <!-- <elasticsearch_field_config>__KOHA_CONF_DIR__/searchengine/elasticsearch/field_config.yaml</elasticsearch_field_config> -->
- <!-- Uncomment the following line if you want to override the Elasticsearch index default settings.
+ <!-- Elasticsearch default index settings config file -->
+ <elasticsearch_index_config>__ELASTICSEARCH_INDEX_CONFIG__</elasticsearch_index_config>
+ <!-- Elasticsearch default field settings config file -->
+ <elasticsearch_field_config>__ELASTICSEARCH_FIELD_CONFIG__</elasticsearch_field_config>
+ <!-- Elasticsearch index mapping settings config file.
       Note that any changes made to the mappings file only take effect if you reset the mappings in
       by visiting /cgi-bin/koha/admin/searchengine/elasticsearch/mappings.pl?op=reset&i_know_what_i_am_doing=1&reset_fields=1.
       Resetting mappings will override any changes made in the Search engine configuration UI.
  -->
- <!-- <elasticsearch_index_mappings>__KOHA_CONF_DIR__/searchengine/elasticsearch/mappings.yaml</elasticsearch_index_mappings> -->
+ <elasticsearch_index_mappings>__ELASTICSEARCH_INDEX_MAPPINGS__</elasticsearch_index_mappings>
 
  <!-- PageObject tests connect to these servers -->
  <testservers>

--- a/rewrite-config.PL
+++ b/rewrite-config.PL
@@ -159,6 +159,9 @@ $prefix = $ENV{'INSTALL_BASE'} || "/usr";
   "__USE_ELASTICSEARCH__" => 'no',
   "__ELASTICSEARCH_SERVERS__" => "",
   "__ELASTICSEARCH_INDEX__" => "koha",
+  "__ELASTICSEARCH_INDEX_CONFIG__" => "",
+  "__ELASTICSEARCH_FIELD_CONFIG__" => "",
+  "__ELASTICSEARCH_INDEX_MAPPINGS__" => "",
   "__FONT_DIR__" => "/usr/share/fonts/truetype/ttf-dejavu",
 );
 


### PR DESCRIPTION
This makes it possible set custom mappings, index and field config
files for Elasticsearch with "make".