### PR TITLE
KD-3115: Improve performance of the checkouts/expanded API

### DIFF
--- a/Koha/Account/Line.pm
+++ b/Koha/Account/Line.pm
@@ -55,8 +55,6 @@ sub TO_JSON {
             my $biblio = $item->biblio;
             if (defined $biblio) {
                 my $title = $biblio->title;
-                my $remainder = $biblio->title_remainder;
-                $title .= ' ' . $remainder if defined $remainder;
                 $json->{description} = $title if defined $title;
             }
         }

--- a/Koha/Biblio.pm
+++ b/Koha/Biblio.pm
@@ -457,22 +457,6 @@ sub subscriptions {
 }
 
 
-=head3 title_remainder
-
-my $field = $self->title_remainder
-
-Returns the Remainder of title, 245$b.
-
-=cut
-
-sub title_remainder {
-    my ($self) = @_;
-
-    $self->{_record} ||= C4::Biblio::GetMarcBiblio($self->biblionumber);
-    return unless my $record = $self->{_record};
-    return $record->subfield('245','b');
-}
-
 =head3 store
 
 =cut
@@ -493,8 +477,6 @@ sub TO_JSON {
     my ($self) = @_;
 
     my $json = $self->SUPER::TO_JSON;
-    my $title_remainder = $self->title_remainder;
-    $json->{'title_remainder'} = $title_remainder if $title_remainder;
     return $json;
 }
 

--- a/api/v1/swagger/definitions/biblio.json
+++ b/api/v1/swagger/definitions/biblio.json
@@ -49,10 +49,6 @@
     "frameworkcode": {
       "type": "string",
       "description": "framework used in cataloging this record"
-    },
-    "title_remainder": {
-      "type": ["string", "null"],
-      "description": "245$b in MARC21"
     }
   }
 }

--- a/api/v1/swagger/definitions/checkoutexpanded.json
+++ b/api/v1/swagger/definitions/checkoutexpanded.json
@@ -23,10 +23,6 @@
       "type": ["string", "null"],
       "description": "title (without the subtitle) from the MARC record (245$a in MARC21)"
     },
-    "title_remainder": {
-      "type": ["string", "null"],
-      "description": "245$b in MARC21"
-    },
     "enumchron": {
       "type": ["string", "null"],
       "description": "serial enumeration/chronology for the item"

--- a/t/db_dependent/Koha/Biblios.t
+++ b/t/db_dependent/Koha/Biblios.t
@@ -39,7 +39,7 @@ my $builder = t::lib::TestBuilder->new;
 my $patron = $builder->build( { source => 'Borrower' } );
 $patron = Koha::Patrons->find( $patron->{borrowernumber} );
 
-my $biblio = Koha::Biblio->new()->store();
+my $biblio = Koha::Biblio->new({datecreated => '2018-01-01'})->store();
 
 my $biblioitem = $schema->resultset('Biblioitem')->new(
     {
@@ -144,22 +144,13 @@ subtest 'can_be_transferred' => sub {
        .' invalid library is given.');
 };
 
-subtest 'title_remainder' => sub {
-    plan tests => 1;
-
-    my ($bibnum, $title, $bibitemnum) = create_helper_biblio('BK');
-
-    my $biblio = Koha::Biblios->find($bibnum);
-    is($biblio->title_remainder, 'Remainder', 'Got remainder of title');
-};
-
 subtest 'store' => sub {
     plan tests => 2;
 
     my ($bibnum, $title, $bibitemnum) = create_helper_biblio('BK');
 
     my $biblio = Koha::Biblios->find($bibnum);
-    $biblio->title_remainder;
+    $biblio->title;
     is(ref($biblio->{_record}), 'MARC::Record',
        'MARC::Record is cached in the object');
     $biblio->store;

--- a/t/db_dependent/api/v1/biblios.t
+++ b/t/db_dependent/api/v1/biblios.t
@@ -82,11 +82,10 @@ subtest 'Create biblio' => sub {
 };
 
 subtest 'getexpanded() tests' => sub {
-    plan tests => 8;
+    plan tests => 6;
 
     my ($bibnum, $title, $bibitemnum) = create_helper_biblio({
-        itemtype => 'BK',
-        remainder_of_title => 'Remainder'
+        itemtype => 'BK'
     });
 
     my $tx = $t->ua->build_tx(GET => "/api/v1/biblios/$bibnum/expanded");
@@ -95,8 +94,7 @@ subtest 'getexpanded() tests' => sub {
     $t->request_ok($tx)
       ->status_is(200);
 
-    $t->json_is('/biblio/biblionumber' => $bibnum)
-      ->json_is('/biblio/title_remainder' => 'Remainder');
+    $t->json_is('/biblio/biblionumber' => $bibnum);
 
     ($bibnum, $title, $bibitemnum) = create_helper_biblio({ itemtype => 'BK' });
 
@@ -106,8 +104,7 @@ subtest 'getexpanded() tests' => sub {
     $t->request_ok($tx)
       ->status_is(200);
 
-    $t->json_is('/biblio/biblionumber' => $bibnum)
-      ->json_hasnt('/biblio/title_remainder');
+    $t->json_is('/biblio/biblionumber' => $bibnum);
 };
 
 subtest 'Delete biblio' => sub {

--- a/t/db_dependent/api/v1/checkoutsexpanded.t
+++ b/t/db_dependent/api/v1/checkoutsexpanded.t
@@ -42,7 +42,7 @@ my $remote_address = '127.0.0.1';
 my $t              = Test::Mojo->new('Koha::REST::V1');
 
 subtest 'get() tests' => sub {
-    plan tests => 42;
+    plan tests => 40;
 
     $schema->storage->txn_begin;
 
@@ -121,7 +121,6 @@ subtest 'get() tests' => sub {
         ->json_is('/1/max_renewals' => 1)
         ->json_is('/0/biblionumber' => $biblionumber)
         ->json_is('/0/title' => 'RESTful Web APIs')
-        ->json_is('/0/title_remainder' => 'The Best')
         ->json_is('/0/enumchron' => 'ecTEST1001')
         ->json_hasnt('/2');
         
@@ -149,7 +148,6 @@ subtest 'get() tests' => sub {
         ->json_is('/1/max_renewals' => 1)
         ->json_is('/0/biblionumber' => $biblionumber)
         ->json_is('/0/title' => 'RESTful Web APIs')
-        ->json_is('/0/title_remainder' => 'The Best')
         ->json_is('/0/enumchron' => 'ecTEST1001')
         ->json_hasnt('/2');
     $schema->storage->txn_rollback;


### PR DESCRIPTION
- Check patron blocks only once outside the loop
- Select all required records from the database with a join instead of requesting them separately
- Remove title_remainder for now since it needs the MARC record
- Check renewability only if patron does not have blocks