### PR TITLE
Bug 15165: (squashable) remove Perl warning

### DIFF
--- a/Koha/Account/Line.pm
+++ b/Koha/Account/Line.pm
@@ -49,7 +49,7 @@ sub TO_JSON {
     $description =~ s/^\s+|\s+$//g if defined $description;
     # If accountline description is an itemnumber, replace it with record title
     if (defined $description && defined $itemnumber &&
-        $description == $itemnumber) {
+        $description eq $itemnumber) {
         my $item = Koha::Items->find($itemnumber);
         if (defined $item) {
             my $biblio = $item->biblio;


### PR DESCRIPTION
Although the code works, Perl gives a warning when comparing string
with a number:

[WARN] Argument "L 46217" isn't numeric in numeric eq (==) at
/home/koha/Koha/Koha/Account/Line.pm line 51.

This compares the two values as a string thus removing the warning.