### PR TITLE
Bug 19487: Fix internal server error when paying fines

### DIFF
--- a/C4/Circulation.pm
+++ b/C4/Circulation.pm
@@ -2249,6 +2249,9 @@ sub MarkIssueReturned {
 
         $dbh->do( $query, undef, @bind );
 
+        # We just updated the returndate, so we need to refetch $issue
+        $issue->discard_changes;
+
         # Create the old_issues entry
         my $old_checkout_data = $issue->unblessed;
 


### PR DESCRIPTION
This cherry-picks commits from [bug 19487](https://bugs.koha-community.org/bugzilla3/show_bug.cgi?id=19487). The higher education libraries are using the circulation rule "Refund lost item fee" set to "No" and it will create lost item fines that are related to an item that is already checked in and therefore leading to the error upon paying the fine as described in the community bug report.