### PR TITLE
KD-3511: REST API: Add support for sorting and paging checkouts

### DIFF
--- a/Koha/REST/V1/Checkout.pm
+++ b/Koha/REST/V1/Checkout.pm
@@ -31,10 +31,30 @@ use Try::Tiny;
 sub list {
     my $c = shift->openapi->valid_input or return;
 
+    my $paging = $c->param('paging') // 0;
+    my $other_params = {};
+    my @columns = Koha::Checkouts->columns;
+    _populate_paging_params($other_params, $c, 'date_due', \@columns);
+
+    my $totalcount = $c->validation->param('totalcount');
     my $borrowernumber = $c->validation->param('borrowernumber');
-    my $checkouts = Koha::Checkouts->search({
+    my %attributes = (
         borrowernumber => $borrowernumber
-    });
+    );
+    my $checkouts = Koha::Checkouts->search(
+        \%attributes,
+        $other_params
+    );
+
+    if ($paging) {
+        my $checkouts_count = Koha::Checkouts->search(
+          \%attributes,
+        )->count;
+        return $c->render( status => 200, openapi => {
+            total => $checkouts_count,
+            records => $checkouts
+        });
+    }
 
     $c->render( status => 200, openapi => $checkouts );
 }
@@ -166,46 +186,19 @@ sub listhistory {
     my $c = shift->openapi->valid_input or return;
 
     my $borrowernumber = $c->validation->param('borrowernumber');
-    my $offset         = $c->validation->param('offset');
-    my $limit          = $c->validation->param('limit');
-    my $sort           = $c->validation->param('sort');
-    my $order          = $c->validation->param('order');
 
     return try {
         my %attributes = ( itemnumber => { "!=", undef } );
         my $other_params = {};
         if ($borrowernumber) {
-        return $c->render( status => 404, openapi => {
-            error => "Patron doesn't exist"
-        }) unless Koha::Patrons->find($borrowernumber);
+            return $c->render( status => 404, openapi => {
+                error => "Patron doesn't exist"
+            }) unless Koha::Patrons->find($borrowernumber);
             $attributes{borrowernumber} = $borrowernumber;
         }
-        if (defined $offset) {
-            $other_params->{offset} = $offset;
-        }
-        if (defined $limit) {
-            $other_params->{rows} = $limit;
-        }
-        if (defined $order) {
-            if ($order =~ /^desc/i) {
-                $other_params->{order_by} = { '-desc' => 'issue_id' };
-            }
-            else {
-                $other_params->{order_by} = { '-asc' => 'issue_id' };
-            }
-        }
-        if (defined $sort) {
-            my @columns = Koha::Old::Checkouts->columns;
-            if (grep(/^$sort$/, @columns)) {
-                if (keys %{$other_params->{'order_by'}}) {
-                    foreach my $param (keys %{$other_params->{'order_by'}}) {
-                        $other_params->{order_by}->{$param} = $sort;
-                    }
-                } else {
-                    $other_params->{order_by}->{'-asc'} = $sort;
-                }
-            }
-        }
+
+        my @columns = Koha::Old::Checkouts->columns;
+        _populate_paging_params($other_params, $c, 'issue_id', \@columns);
 
         my $checkouts_count = Koha::Old::Checkouts->search(
           \%attributes,
@@ -254,46 +247,68 @@ sub gethistory {
 sub expanded {
     my $c = shift->openapi->valid_input or return;
 
+    my $paging = $c->param('paging') // 0;
     my $borrowernumber = $c->validation->param('borrowernumber');
     my $borrower = C4::Members::GetMember( borrowernumber => $borrowernumber )
       or return;
     my $user = $c->stash('koha.user');
     my $opac_renewability = _opac_renewal_allowed($user, $borrowernumber);
+
+    my %attributes = (
+        borrowernumber => $borrowernumber
+    );
+    my $other_params = {
+        join => { 'item' => ['biblio', 'biblioitem'] },
+        '+select' => [
+            'item.itype', 'item.homebranch', 'item.holdingbranch', 'item.ccode', 'item.permanent_location', 'item.sub_location',
+            'item.genre', 'item.circulation_level', 'item.reserve_level', 'item.enumchron', 'item.biblionumber',
+            'biblioitem.itemtype',
+            'biblio.title'
+        ],
+        '+as' => [
+            'item_itype', 'homebranch', 'holdingbranch', 'ccode', 'permanent_location', 'sub_location',
+            'genre', 'circulation_level', 'reserve_level', 'enumchron', 'biblionumber',
+            'biblio_itype',
+            'title'
+        ]
+    };
+
+    if ($paging) {
+        my @columns = Koha::Checkouts->columns;
+        push (@columns, 'title');
+        _populate_paging_params($other_params, $c, 'date_due', \@columns);
+    }
+
     my $checkouts = Koha::Checkouts->search(
-        {
-            borrowernumber => $borrowernumber
-        },
-        {
-            join => { 'item' => ['biblio', 'biblioitem'] },
-            '+select' => [
-                'item.itype', 'item.homebranch', 'item.holdingbranch', 'item.ccode', 'item.permanent_location', 'item.sub_location', 
-                'item.genre', 'item.circulation_level', 'item.reserve_level', 'item.enumchron', 'item.biblionumber',
-                'biblioitem.itemtype',
-                'biblio.title'
-            ],
-            '+as' => [
-                'item_itype', 'homebranch', 'holdingbranch', 'ccode', 'permanent_location', 'sub_location', 
-                'genre', 'circulation_level', 'reserve_level', 'enumchron', 'biblionumber',
-                'biblio_itype',
-                'title'
-            ]
-        }
+        \%attributes,
+        $other_params
     );
     my $checkouts_json = $checkouts->TO_JSON;
 
-    my $patron_blocks = '';
     # TODO: Create Koha::Availability::Renew for checking renewability
     #       via Koha::Availability
-    my $patron_checks = Koha::Availability::Checks::Patron->new(
-        scalar Koha::Patrons->find($borrowernumber)
-    );
-    if ((my $err = $patron_checks->debt_renew_opac ||
-        $patron_checks->debarred || $patron_checks->gonenoaddress ||
-        $patron_checks->lost || $patron_checks->expired)
-    ) {
-        $err = ref($err);
-        $err =~ s/Koha::Exceptions::Patron:://;
-        $patron_blocks = lc($err);
+    my $patron_blocks = '';
+    # Disallow renewal if OpacRenewalAllowed is off and user has insufficient rights
+    unless (C4::Context->preference('OpacRenewalAllowed')) {
+        my $user = $c->stash('koha.user');
+        unless ($user && haspermission($user->userid, {
+            circulate => "circulate_remaining_permissions" })) {
+            $patron_blocks = "NoMoreRenewals";
+        }
+    }
+
+    if ($patron_blocks eq '') {
+        my $patron_checks = Koha::Availability::Checks::Patron->new(
+            scalar Koha::Patrons->find($borrowernumber)
+        );
+        if ((my $err = $patron_checks->debt_renew_opac ||
+            $patron_checks->debarred || $patron_checks->gonenoaddress ||
+            $patron_checks->lost || $patron_checks->expired)
+        ) {
+            $err = ref($err);
+            $err =~ s/Koha::Exceptions::Patron:://;
+            $patron_blocks = lc($err);
+        }
     }
     # END TODO
 
@@ -342,6 +357,16 @@ sub expanded {
         $checkout->{'renewability_error'} = $blocks;
     }
 
+    if ($paging) {
+        my $checkouts_count = Koha::Checkouts->search(
+          \%attributes,
+        )->count;
+        return $c->render( status => 200, openapi => {
+            total => $checkouts_count,
+            records => $checkouts_json
+        });
+    }
+
     return $c->render( status => 200, openapi => $checkouts_json );
 }
 
@@ -382,6 +407,52 @@ sub _opac_renewal_allowed {
         return 0;
     }
     return 1;
+}
+
+
+=head3 _populate_paging_params
+
+
+my @columns = Koha::Old::Checkouts->columns;
+_populate_paging_params($c->openapi->valid_input, $dbix_params, 'issue_id', \@columns);
+
+Process offset, limit, sort and order params from the input and set dbix_params accordingly
+
+=cut
+
+sub _populate_paging_params {
+    my ($dbix_params, $c, $default_sort, $columns) = @_;
+
+    my $offset = $c->validation->param('offset');
+    my $limit  = $c->validation->param('limit');
+    my $sort   = $c->validation->param('sort');
+    my $order  = $c->validation->param('order');
+
+    if (defined $offset) {
+        $dbix_params->{offset} = $offset;
+    }
+    if (defined $limit) {
+        $dbix_params->{rows} = $limit;
+    }
+    if ($default_sort) {
+        if (defined $order && $order =~ /^desc/i) {
+            $dbix_params->{order_by} = { '-desc' => $default_sort };
+        }
+        else {
+            $dbix_params->{order_by} = { '-asc' => $default_sort };
+        }
+    }
+    if (defined $sort) {
+        if (grep(/^$sort$/, @{$columns})) {
+            if (keys %{$dbix_params->{'order_by'}}) {
+                foreach my $param (keys %{$dbix_params->{'order_by'}}) {
+                    $dbix_params->{order_by}->{$param} = $sort;
+                }
+            } else {
+                $dbix_params->{order_by}->{'-asc'} = $sort;
+            }
+        }
+    }
 }
 
 1;

--- a/api/v1/swagger/paths.json
+++ b/api/v1/swagger/paths.json
@@ -62,6 +62,9 @@
   "/checkouts": {
     "$ref": "paths/checkouts.json#/~1checkouts"
   },
+  "/checkouts/paged": {
+    "$ref": "paths/checkouts.json#/~1checkouts~1paged"
+  },
   "/checkouts/{checkout_id}": {
     "$ref": "paths/checkouts.json#/~1checkouts~1{checkout_id}"
   },
@@ -70,6 +73,9 @@
   },
   "/checkouts/expanded": {
     "$ref": "paths/checkouts.json#/~1checkouts~1expanded"
+  },
+  "/checkouts/expanded/paged": {
+    "$ref": "paths/checkouts.json#/~1checkouts~1expanded~1paged"
   },
   "/checkouts/history": {
     "$ref": "paths/checkouts.json#/~1checkouts~1history"

--- a/api/v1/swagger/paths/checkouts.json
+++ b/api/v1/swagger/paths/checkouts.json
@@ -53,6 +53,100 @@
       }
     }
   },
+  "/checkouts/paged": {
+    "get": {
+      "x-mojo-to": ["Checkout#list", {"paging": 1}],
+      "operationId": "listCheckoutsPaged",
+      "tags": ["patrons", "checkouts"],
+      "parameters": [
+        { "$ref": "../parameters.json#/borrowernumberQueryParam" },
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by column name. E.g. 'date_due'",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "order",
+          "in": "query",
+          "description": "Ascending (asc) or descending (desc) order. Default ascending. E.g. 'desc'",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "offset",
+          "in": "query",
+          "description": "Offset. Default 0.",
+          "required": false,
+          "type": "integer"
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "description": "Limit results. By default, returns all results.",
+          "required": false,
+          "type": "integer"
+        }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A list of checkouts",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer",
+                "description": "Total number of checkouts, excluding all limitations made by limit and offset query parameters. Please note that because of this, the number may not be equal to the array elements returned in 'records' array."
+              },
+              "records": {
+                "type": "array",
+                "items": {
+                  "$ref": "../definitions.json#/checkout"
+                }
+              }
+            }
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "404": {
+          "description": "Patron not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "circulate": "circulate_remaining_permissions"
+        }
+      }
+    }
+  },
   "/checkouts/{checkout_id}": {
     "get": {
       "x-mojo-to": "Checkout#get",
@@ -216,6 +310,100 @@
             "type": "array",
             "items": {
               "$ref": "../definitions.json#/checkoutexpanded"
+            }
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "404": {
+          "description": "Patron not found",
+          "schema": { "$ref": "../definitions.json#/error" }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "allow-owner": true,
+        "allow-guarantor": true,
+        "permissions": {
+          "circulate": "circulate_remaining_permissions"
+        }
+      }
+    }
+  },
+  "/checkouts/expanded/paged": {
+    "get": {
+      "x-mojo-to": ["Checkout#expanded", {"paging": 1}],
+      "operationId": "expandedCheckoutsPaged",
+      "tags": ["patrons", "checkouts"],
+      "parameters": [
+        { "$ref": "../parameters.json#/borrowernumberQueryParam" },
+        {
+          "name": "sort",
+          "in": "query",
+          "description": "Sort by column name. E.g. 'date_due'",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "order",
+          "in": "query",
+          "description": "Ascending (asc) or descending (desc) order. Default ascending. E.g. 'desc'",
+          "required": false,
+          "type": "string"
+        },
+        {
+          "name": "offset",
+          "in": "query",
+          "description": "Offset. Default 0.",
+          "required": false,
+          "type": "integer"
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "description": "Limit results. By default, returns all results.",
+          "required": false,
+          "type": "integer"
+        }
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "200": {
+          "description": "A list of expanded checkouts with paging",
+          "schema": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer",
+                "description": "Total number of checkouts, excluding all limitations made by limit and offset query parameters. Please note that because of this, the number may not be equal to the array elements returned in 'records' array."
+              },
+              "records": {
+                "type": "array",
+                "items": {
+                    "$ref": "../definitions.json#/checkoutexpanded"
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
Adds endpoints v1/checkouts/paged and v1/checkouts/expanded/paged with parameters sort, order, offset and limit in addition to the ones supported by the normal v1/checkouts and v1/checkouts/expanded endpoints. Extends tests to cover these. Adds check for OpacRenewalAllowed preference to checkouts/expanded[/paged].

Needs review from someone else before committing.