### PR TITLE
Bug 20114: Use user search parameters instead of recreating them

### DIFF
--- a/catalogue/search.pl
+++ b/catalogue/search.pl
@@ -628,6 +628,7 @@ for (my $i=0;$i<@servers;$i++) {
             $template->param(limit_cgi_not_only_host_items=> $limit_cgi_not_only_host_items);
             $template->param(limit_cgi => $limit_cgi);
             $template->param(query_cgi => $query_cgi);
+            $template->param(full_query => $ENV{QUERY_STRING});
             $template->param(query_desc => $query_desc);
             $template->param(limit_desc => $limit_desc);
             $template->param(offset     => $offset);

--- a/koha-tmpl/intranet-tmpl/js/browser.js
+++ b/koha-tmpl/intranet-tmpl/js/browser.js
@@ -30,15 +30,15 @@ KOHA.browser = function (searchid, biblionumber) {
     var browseRecords = function (movement) {
         var newSearchPos = me.curPos + movement;
         if (newSearchPos > current_search.results.length - 1) {
-            window.location = '/cgi-bin/koha/catalogue/search.pl?' + decodeURIComponent(current_search.query) + '&limit=' + decodeURIComponent(current_search.limit) + '&sort=' + current_search.sort + '&gotoPage=detail.pl&gotoNumber=first&searchid=' + me.searchid + '&offset=' + newSearchPos;
+            window.location = '/cgi-bin/koha/catalogue/search.pl?' + decodeURIComponent(current_search.full_query.replace(/&offset(=[^&]*)?|^offset(=[^&]*)?&?/g, '')) + '&gotoPage=detail.pl&gotoNumber=first&searchid=' + me.searchid + '&offset=' + newSearchPos;
         } else if (newSearchPos < 0) {
-            window.location = '/cgi-bin/koha/catalogue/search.pl?' + decodeURIComponent(current_search.query) + '&limit=' + decodeURIComponent(current_search.limit) + '&sort=' + current_search.sort + '&gotoPage=detail.pl&gotoNumber=last&searchid=' + me.searchid + '&offset=' + (me.offset - current_search.pagelen);
+            window.location = '/cgi-bin/koha/catalogue/search.pl?' + decodeURIComponent(current_search.full_query.replace(/&offset(=[^&]*)?|^offset(=[^&]*)?&?/g, '')) + '&gotoPage=detail.pl&gotoNumber=last&searchid=' + me.searchid + '&offset=' + (me.offset - current_search.pagelen);
         } else {
             window.location = window.location.href.replace('biblionumber=' + biblionumber, 'biblionumber=' + current_search.results[newSearchPos]);
         }
     }
 
-    me.create = function (offset, query, limit, sort, newresults, total) {
+    me.create = function (offset, query, limit, sort, newresults, total, full_query) {
         if (current_search) {
             if (offset === current_search.offset - newresults.length) {
                 current_search.results = newresults.concat(current_search.results);
@@ -51,6 +51,7 @@ KOHA.browser = function (searchid, biblionumber) {
         if (!current_search) {
             current_search = { offset: offset,
                 query: query,
+                full_query: full_query,
                 limit: limit,
                 sort:  sort,
                 pagelen: newresults.length,
@@ -89,7 +90,7 @@ KOHA.browser = function (searchid, biblionumber) {
 
             $(document).ready(function () {
                 if (me.curPos > -1) {
-                    var searchURL = '/cgi-bin/koha/catalogue/search.pl?' + decodeURIComponent(current_search.query) + '&limit=' + decodeURIComponent(current_search.limit) + '&sort=' + current_search.sort + '&searchid=' + me.searchid + '&offset=' + me.offset;
+                    var searchURL = '/cgi-bin/koha/catalogue/search.pl?' + decodeURIComponent(current_search.full_query.replace(/&offset(=[^&]*)?|^offset(=[^&]*)?&?/g, '')) + '&offset=' + me.offset;
                     var prevbutton;
                     var nextbutton;
                     if (me.curPos === 0 && current_search.offset === 1) {

--- a/koha-tmpl/intranet-tmpl/prog/en/includes/page-numbers.inc
+++ b/koha-tmpl/intranet-tmpl/prog/en/includes/page-numbers.inc
@@ -1,19 +1,19 @@
 [% IF ( PAGE_NUMBERS ) %]<nav><ul class="pagination">
  [% IF hits_to_paginate < total %]<h6>[% hits_to_paginate %] of [% total %] results loaded, refine your search to view other records</h6>[% END %]
     [% IF ( previous_page_offset.defined ) %]
-        <li><a href="/cgi-bin/koha/catalogue/search.pl?[% query_cgi |html %][% limit_cgi |html %][% IF ( sort_by ) %]&amp;sort_by=[% sort_by |url %][% END %]">First</a></li>
+        <li><a href="/cgi-bin/koha/catalogue/search.pl?[% full_query |replace('&offset(=[^&]*)?|^offset(=[^&]*)?&?', '') |html %]">First</a></li>
         <!-- Row of numbers corresponding to search result pages -->
-        <li><a href="/cgi-bin/koha/catalogue/search.pl?[% query_cgi |html %][% limit_cgi |html %]&amp;offset=[% previous_page_offset %][% IF ( sort_by ) %]&amp;sort_by=[% sort_by |url %][% END %]">&lt;&lt; Previous</a></li>
+        <li><a href="/cgi-bin/koha/catalogue/search.pl?[% full_query |replace('&offset(=[^&]*)?|^offset(=[^&]*)?&?', '') |html %]&amp;offset=[% previous_page_offset %]">&lt;&lt; Previous</a></li>
     [% END %]
     [% FOREACH PAGE_NUMBER IN PAGE_NUMBERS %]
         [% IF ( PAGE_NUMBER.highlight ) %]
             <li class="active"><span>[% PAGE_NUMBER.pg %]</span></li>
         [% ELSE %]
-            <li><a href="/cgi-bin/koha/catalogue/search.pl?[% query_cgi |html %][% limit_cgi |html %]&amp;offset=[% PAGE_NUMBER.offset %][% IF ( sort_by ) %]&amp;sort_by=[% sort_by |url %][% END %]">[% PAGE_NUMBER.pg %]</a></li>
+            <li><a href="/cgi-bin/koha/catalogue/search.pl?[% full_query |replace('&offset(=[^&]*)?|^offset(=[^&]*)?&?', '') |html %]&amp;offset=[% PAGE_NUMBER.offset %]">[% PAGE_NUMBER.pg %]</a></li>
         [% END %]
     [% END %]
     [% IF ( next_page_offset ) %]
-        <li><a href="/cgi-bin/koha/catalogue/search.pl?[% query_cgi |html %][% limit_cgi |html %]&amp;offset=[% next_page_offset %][% IF ( sort_by ) %]&amp;sort_by=[% sort_by |url %][% END %]">Next &gt;&gt;</a></li>
-        <li><a href="/cgi-bin/koha/catalogue/search.pl?[% query_cgi |html %][% limit_cgi |html %]&amp;offset=[% last_page_offset %][% IF ( sort_by ) %]&amp;sort_by=[% sort_by |url %][% END %]">Last</a></li>
+        <li><a href="/cgi-bin/koha/catalogue/search.pl?[% full_query |replace('&offset(=[^&]*)?|^offset(=[^&]*)?&?', '') |html %]&amp;offset=[% next_page_offset %]">Next &gt;&gt;</a></li>
+        <li><a href="/cgi-bin/koha/catalogue/search.pl?[% full_query |replace('&offset(=[^&]*)?|^offset(=[^&]*)?&?', '') |html %]&amp;offset=[% last_page_offset %]">Last</a></li>
     [% END %]
 </ul></nav>[% END %]

--- a/koha-tmpl/intranet-tmpl/prog/en/modules/catalogue/results.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/catalogue/results.tt
@@ -176,7 +176,7 @@ $('#sort_by').change(function() {
         ];
         var browser = KOHA.browser('[% searchid %]', parseInt('[% biblionumber %]', 10));
         browser.create([% SEARCH_RESULTS.first.result_number %], '[% query_cgi %]', '[% limit_cgi | uri %]','[% sort_cgi | uri %]',
-               newresults, '[% total %]');
+               newresults, '[% total %]', '[% full_query %]');
     [% END %]
     [% IF (gotoPage && gotoNumber) %]
         [% IF (gotoNumber == 'first') %]


### PR DESCRIPTION
This commit replaces the way of calling build_query_compat to recreate
the user submitted search query and instead simply copies the search
query and modifies offset to the correct one. This eliminates bugs
that could happen if build_query_compat() is not up-to-date with the
current range of search parameters available for the user.