### PR TITLE
KD-3593: Add MARC preview links to holdings list

### DIFF
--- a/catalogue/showmarc.pl
+++ b/catalogue/showmarc.pl
@@ -33,6 +33,7 @@ use C4::Context;
 use C4::Output;
 use C4::Auth;
 use C4::Biblio;
+use C4::Holdings;
 use C4::ImportBatch;
 use C4::XSLT ();
 
@@ -40,9 +41,13 @@ my $input= new CGI;
 my $biblionumber= $input->param('id');
 my $importid= $input->param('importid');
 my $view= $input->param('viewas')||'';
+my $holding_id= $input->param('holding_id')||'';
 
 my $record;
-if ($importid) {
+if ($holding_id) {
+    $record = C4::Holdings::GetMarcHolding($holding_id);
+} 
+elsif ($importid) {
     $record = C4::ImportBatch::GetRecordFromImportBiblio( $importid, 'embed_items' );
 }
 else {
@@ -54,7 +59,7 @@ if(!ref $record) {
 }
 
 if($view eq 'card' || $view eq 'html') {
-    my $xml = $importid ? $record->as_xml(): GetXmlBiblio($biblionumber);
+    my $xml = $record->as_xml();
     my $xsl;
     if ( $view eq 'card' ){
         $xsl = C4::Context->preference('marcflavour') eq 'UNIMARC'

--- a/koha-tmpl/intranet-tmpl/prog/en/modules/catalogue/detail.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/catalogue/detail.tt
@@ -689,9 +689,10 @@ function verify_images() {
                         </td>
                     [% IF CAN_user_editcatalogue_edit_items %]
                         <td class="actions">
-                            <a class="btn btn-default btn-xs" href="/cgi-bin/koha/cataloguing/addholding.pl?op=edit&biblionumber=[% holding.biblionumber %]&holding_id=[% holding.holding_id %]#editholding"><i class="fa fa-pencil"></i> Edit</a>
-                            <a class="btn btn-default btn-xs delete" href="/cgi-bin/koha/cataloguing/addholding.pl?op=delete&biblionumber=[% holding.biblionumber %]&holding_id=[% holding.holding_id %]"><i class="fa fa-eraser"></i> Delete</a>
-                            <a class="btn btn-default btn-xs" href="/cgi-bin/koha/cataloguing/additem.pl?biblionumber=[% holding.biblionumber %]&holding_id=[% holding.holding_id %]#additema"><i class="fa fa-plus"></i> Add item</a>
+                            <a class="btn btn-default btn-xs" href="/cgi-bin/koha/cataloguing/addholding.pl?op=edit&biblionumber=[% holding.biblionumber | url %]&holding_id=[% holding.holding_id | url %]#editholding"><i class="fa fa-pencil"></i> Edit</a>
+                            <a class="btn btn-default btn-xs delete" href="/cgi-bin/koha/cataloguing/addholding.pl?op=delete&biblionumber=[% holding.biblionumber | url %]&holding_id=[% holding.holding_id | url %]"><i class="fa fa-eraser"></i> Delete</a>
+                            <a class="btn btn-default btn-xs" href="/cgi-bin/koha/cataloguing/additem.pl?biblionumber=[% holding.biblionumber %]&holding_id=[% holding.holding_id | url%]#additema"><i class="fa fa-plus"></i> Add item</a>
+                            <a class="btn btn-default btn-xs previewMARC" href="/cgi-bin/koha/catalogue/showmarc.pl?holding_id=[% holding.holding_id | url %]&amp;viewas=html" title="MARC" class="">Show MARC</a>
                         </td>
                     [% END %]
                     </tr>


### PR DESCRIPTION
Since there can be various fields that the user might want to quickly check, add a MARC preview button to the holdings list. Please feel free to rebase to bug 20447 if necessary.