### PR TITLE
KD-3625: Add support for component parts with Elasticsearch, improvem…

### DIFF
--- a/C4/Search.pm
+++ b/C4/Search.pm
@@ -441,6 +441,9 @@ sub getRecords {
             elsif ( $sort eq "title_za" || $sort eq "title_dsc" ) {
                 $sort_by .= "1=4 >i ";
             }
+            elsif ( $sort eq "id_asc") {
+                $sort_by .= "1=12 <i ";
+            }
             else {
                 warn "Ignoring unrecognized sort '$sort' requested" if $sort_by;
             }

--- a/C4/XSLT.pm
+++ b/C4/XSLT.pm
@@ -430,7 +430,7 @@ sub engine {
 sub _prepareComponentPartRecords {
 
     my ($f001Data, $f003Data) = @_;
-    my $componentPartBiblios = C4::Biblio::getComponentRecords( $f001Data, $f003Data );
+    my ($componentPartBiblios, $totalCount, $query) = C4::Biblio::getComponentRecords( $f001Data, $f003Data );
 
     if (@$componentPartBiblios) {
 
@@ -442,7 +442,8 @@ sub _prepareComponentPartRecords {
             push @componentPartRecordXML, decode('utf8', $cb);
         }
         push @componentPartRecordXML, '</componentPartRecords>';
-
+        push @componentPartRecordXML, '<componentPartRecordCount>' . C4::Koha::xml_escape($totalCount) . "</componentPartRecordCount>\n";
+        push @componentPartRecordXML, '<componentPartSearchQuery>' . C4::Koha::xml_escape($query) . "</componentPartSearchQuery>\n";
         #Build the real XML string.
         return join "\n", @componentPartRecordXML;
     }

--- a/Koha/SearchEngine/Elasticsearch/QueryBuilder.pm
+++ b/Koha/SearchEngine/Elasticsearch/QueryBuilder.pm
@@ -487,6 +487,7 @@ sub _convert_sort_fields {
         relevance   => undef,       # default
         title       => 'title',
         pubdate     => 'pubdate',
+        id          => 'Local-number'
     );
     my %sort_order_convert =
       ( qw( desc desc ), qw( dsc desc ), qw( asc asc ), qw( az asc ), qw( za desc ) );
@@ -530,6 +531,9 @@ our %index_field_convert = (
     'mus'     => 'rtype',
     'aud'     => 'ta',
     'hi'      => 'Host-Item-Number',
+    'rcn'     => 'record-control-number',
+    'cni'     => 'control-number-identifier',
+    'Control-number' => 'control-number'
 );
 
 sub _convert_index_fields {

--- a/admin/searchengine/elasticsearch/mappings.yaml
+++ b/admin/searchengine/elasticsearch/mappings.yaml
@@ -559,6 +559,20 @@ biblios:
         sort: ~
         suggestible: ''
     type: number
+  record-control-number:
+    label: record-control-number
+    mappings:
+      - facet: ''
+        marc_field: '773w'
+        marc_type: marc21
+        sort: ~
+        suggestible: ''
+      - facet: ''
+        marc_field: '773w'
+        marc_type: normarc
+        sort: ~
+        suggestible: ''
+    type: string
   Local-number:
     label: Local-number
     mappings:
@@ -1285,6 +1299,20 @@ biblios:
         suggestible: ''
       - facet: ''
         marc_field: '001'
+        marc_type: normarc
+        sort: ~
+        suggestible: ''
+    type: ''
+  control-number-identifier:
+    label: control-number-identifier
+    mappings:
+      - facet: ''
+        marc_field: '003'
+        marc_type: marc21
+        sort: ~
+        suggestible: ''
+      - facet: ''
+        marc_field: '003'
         marc_type: normarc
         sort: ~
         suggestible: ''

--- a/etc/zebradb/marc_defs/marc21/biblios/biblio-koha-indexdefs.xml
+++ b/etc/zebradb/marc_defs/marc21/biblios/biblio-koha-indexdefs.xml
@@ -18,10 +18,12 @@
   <!--record.abs line 43: melm 001        Control-number-->
   <index_control_field tag="001">
     <target_index>Control-number:w</target_index>
+    <target_index>Control-number:p</target_index>
   </index_control_field>
   <!--record.abs line 43: melm 003        Control-number-identifier-->
   <index_control_field xmlns="http://www.koha-community.org/schemas/index-defs" tag="003">
     <target_index>Control-number-identifier:w</target_index>
+    <target_index>Control-number-identifier:p</target_index>
   </index_control_field>
   <!--record.abs line 44: melm 005        Date/time-last-modified-->
   <index_control_field tag="005">
@@ -1003,6 +1005,7 @@
   <!--record.abs line 232: melm 773$w      Record-control-number-->
   <index_subfields tag="773" subfields="w">
     <target_index>Record-control-number:w</target_index>
+    <target_index>Record-control-number:p</target_index>
   </index_subfields>
   <!--record.abs line 233: melm 774$w      Record-control-number-->
   <index_subfields tag="774" subfields="w">

--- a/etc/zebradb/marc_defs/marc21/biblios/biblio-zebra-indexdefs.xsl
+++ b/etc/zebradb/marc_defs/marc21/biblios/biblio-zebra-indexdefs.xsl
@@ -61,12 +61,12 @@ definition file (probably something like {biblio,authority}-koha-indexdefs.xml) 
     </z:index>
   </xslo:template>
   <xslo:template match="marc:controlfield[@tag='001']">
-    <z:index name="Control-number:w">
+    <z:index name="Control-number:w Control-number:p">
       <xslo:value-of select="."/>
     </z:index>
   </xslo:template>
   <xslo:template match="marc:controlfield[@tag='003']">
-    <z:index name="Control-number-identifier:w">
+    <z:index name="Control-number-identifier:w Control-number-identifier:p">
       <xslo:value-of select="."/>
     </z:index>
   </xslo:template>
@@ -990,7 +990,7 @@ definition file (probably something like {biblio,authority}-koha-indexdefs.xml) 
     </xslo:for-each>
     <xslo:for-each select="marc:subfield">
       <xslo:if test="contains('w', @code)">
-        <z:index name="Record-control-number:w">
+        <z:index name="Record-control-number:w Record-control-number:p">
           <xslo:value-of select="."/>
         </z:index>
       </xslo:if>

--- a/koha-tmpl/intranet-tmpl/prog/css/staff-global.css
+++ b/koha-tmpl/intranet-tmpl/prog/css/staff-global.css
@@ -1836,6 +1836,10 @@ span.permissiondesc {
     overflow-y: auto;
     overflow-x: hidden;
     max-width: 50%;
+    border: 1px solid #E6F0F2;
+}
+.componentPartRecordsContainer h5 {
+    padding-left: 0.5em;
 }
 ol.componentParts {
     padding-left: 3.2em;

--- a/koha-tmpl/intranet-tmpl/prog/en/xslt/MARC21slim2intranetDetail.xsl
+++ b/koha-tmpl/intranet-tmpl/prog/en/xslt/MARC21slim2intranetDetail.xsl
@@ -8,7 +8,8 @@
   xmlns:marc="http://www.loc.gov/MARC21/slim"
   xmlns:items="http://www.koha-community.org/items"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  exclude-result-prefixes="marc items">
+  xmlns:str="http://exslt.org/strings"
+  exclude-result-prefixes="marc items str">
     <xsl:import href="MARC21slimUtils.xsl"/>
     <xsl:output method = "html" indent="yes" omit-xml-declaration = "yes" encoding="UTF-8"/>
     <xsl:template match="/">
@@ -114,61 +115,71 @@
         <!-- Component part records: Displaying title and author of component part records -->
         <xsl:if test="marc:componentPartRecords">
             <span class="results_summary componentPartRecordsContainer">
-                <h5>Component part records:</h5>
+                <h5>Component part records (<a><xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=<xsl:value-of select="str:encode-uri(marc:componentPartSearchQuery, true())"/></xsl:attribute>view all <xsl:value-of select="marc:componentPartRecordCount"/></a>):</h5>
+                <xsl:variable name="componentPartDisplayCount"><xsl:value-of select="count(marc:componentPartRecords/marc:record)"/></xsl:variable>
                 <ol class="componentParts">
                     <xsl:for-each select="marc:componentPartRecords/marc:record">
                         <li>
-                            <span class="componentPartRecord">
-                                <span class="componentPartRecordTitle">
-                                    <a>
-                                    <xsl:attribute name="href">/cgi-bin/koha/catalogue/detail.pl?biblionumber=<xsl:value-of select="marc:datafield[@tag=999]/marc:subfield[@code='c']" /></xsl:attribute>
-                                    <xsl:choose>
-                                        <xsl:when test="marc:datafield[@tag=245]/marc:subfield[@code='a']">
-                                            <xsl:value-of select="substring-before( concat(marc:datafield[@tag=245]/marc:subfield[@code='a'], '/'), '/')" />
+                            <xsl:choose>
+                                <xsl:when test="position() &lt; $componentPartDisplayCount or $componentPartDisplayCount = //marc:componentPartRecordCount">
+                                    <span class="componentPartRecord">
+                                        <span class="componentPartRecordTitle">
+                                            <a>
+                                            <xsl:attribute name="href">/cgi-bin/koha/catalogue/detail.pl?biblionumber=<xsl:value-of select="marc:datafield[@tag=999]/marc:subfield[@code='c']" /></xsl:attribute>
+                                            <xsl:choose>
+                                                <xsl:when test="marc:datafield[@tag=245]/marc:subfield[@code='a']">
+                                                    <xsl:value-of select="substring-before( concat(marc:datafield[@tag=245]/marc:subfield[@code='a'], '/'), '/')" />
+                                                </xsl:when>
+                                                <xsl:when test="marc:datafield[@tag=240]/marc:subfield[@code='a']">
+                            <xsl:for-each select="marc:datafield[@tag=240]">
+                                <xsl:call-template name="chopPunctuation">
+                                <xsl:with-param name="chopString">
+                                <xsl:call-template name="subfieldSelect">
+                                <xsl:with-param name="codes">amnp</xsl:with-param>
+                                </xsl:call-template>
+                                </xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:for-each>
+                                                </xsl:when>
+                                                <xsl:when test="marc:datafield[@tag=130]/marc:subfield[@code='a']">
+                            <xsl:for-each select="marc:datafield[@tag=130]">
+                                <xsl:call-template name="chopPunctuation">
+                                <xsl:with-param name="chopString">
+                                <xsl:call-template name="subfieldSelect">
+                                <xsl:with-param name="codes">amnp</xsl:with-param>
+                                </xsl:call-template>
+                                </xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:for-each>
+                                                </xsl:when>
+                                                <xsl:otherwise>
+                                                    <xsl:text>[Record with no title statement]</xsl:text>
+                                                </xsl:otherwise>
+                                            </xsl:choose>
+                                            </a>
+                                        </span>
+                        <xsl:choose>
+                                        <xsl:when test="marc:datafield[@tag=100]/marc:subfield[@code='a']">
+                                            -
+                                            <span class="componentPartRecordAuthor">
+                                                <xsl:value-of select="marc:datafield[@tag=100]/marc:subfield[@code='a']" />
+                                            </span>
                                         </xsl:when>
-                                        <xsl:when test="marc:datafield[@tag=240]/marc:subfield[@code='a']">
-					  <xsl:for-each select="marc:datafield[@tag=240]">
-					    <xsl:call-template name="chopPunctuation">
-					      <xsl:with-param name="chopString">
-						<xsl:call-template name="subfieldSelect">
-						  <xsl:with-param name="codes">amnp</xsl:with-param>
-						</xsl:call-template>
-					      </xsl:with-param>
-					    </xsl:call-template>
-					  </xsl:for-each>
+                                        <xsl:when test="marc:datafield[@tag=110]/marc:subfield[@code='a']">
+                                            -
+                                            <span class="componentPartRecordAuthor">
+                                                <xsl:value-of select="marc:datafield[@tag=110]/marc:subfield[@code='a']" />
+                                            </span>
                                         </xsl:when>
-                                        <xsl:when test="marc:datafield[@tag=130]/marc:subfield[@code='a']">
-					  <xsl:for-each select="marc:datafield[@tag=130]">
-					    <xsl:call-template name="chopPunctuation">
-					      <xsl:with-param name="chopString">
-						<xsl:call-template name="subfieldSelect">
-						  <xsl:with-param name="codes">amnp</xsl:with-param>
-						</xsl:call-template>
-					      </xsl:with-param>
-					    </xsl:call-template>
-					  </xsl:for-each>
-                                        </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:text>[Record with no title statement]</xsl:text>
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                    </a>
-                                </span>
-				<xsl:choose>
-                                  <xsl:when test="marc:datafield[@tag=100]/marc:subfield[@code='a']">
-                                    -
-                                    <span class="componentPartRecordAuthor">
-                                        <xsl:value-of select="marc:datafield[@tag=100]/marc:subfield[@code='a']" />
+                        </xsl:choose>
                                     </span>
-                                  </xsl:when>
-                                  <xsl:when test="marc:datafield[@tag=110]/marc:subfield[@code='a']">
-                                    -
-                                    <span class="componentPartRecordAuthor">
-                                        <xsl:value-of select="marc:datafield[@tag=110]/marc:subfield[@code='a']" />
+                                </xsl:when>
+                                <xsl:when test="position() = $componentPartDisplayCount">
+                                    <span class="componentPartRecordTitle">
+                                        [list truncated - <a><xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=<xsl:value-of select="str:encode-uri(//marc:componentPartSearchQuery, true())"/></xsl:attribute>view all</a>]
                                     </span>
-                                  </xsl:when>
-				</xsl:choose>
-                            </span>
+                                </xsl:when>
+                            </xsl:choose>
                         </li>
                     </xsl:for-each>
                 </ol>
@@ -393,7 +404,26 @@
             <a>
             <xsl:choose>
             <xsl:when test="$UseControlNumber = '1' and marc:subfield[@code='w']">
-                <xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=Control-number:<xsl:call-template name="extractControlNumber"><xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/></xsl:call-template></xsl:attribute>
+                <xsl:variable name="f773cn">
+                    <xsl:call-template name="extractControlNumber">
+                        <xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/>
+                    </xsl:call-template>
+                </xsl:variable>
+                <xsl:variable name="f773cni">
+                    <xsl:call-template name="extractControlNumberIdentifier">
+                        <xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/>
+                    </xsl:call-template>
+                </xsl:variable>
+                <xsl:choose>
+                    <!-- N.B. The query format has been carefully crafted to work with both Zebra and Elasticsearch... -->
+                    <xsl:when test="$f773cni != ''">
+                        <xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=Control-number,ext:"<xsl:value-of select="str:encode-uri($f773cn, true())"/>" AND cni,ext:"<xsl:value-of select="str:encode-uri($f773cni, true())"/>"</xsl:attribute>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=Control-number,ext:"<xsl:value-of select="str:encode-uri($f773cn, true())"/>" AND cni,ext:"<xsl:value-of select="str:encode-uri($controlField003, true())"/>"</xsl:attribute>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:value-of select="translate($f773, '()', '')"/>
             </xsl:when>
             <xsl:otherwise>
                 <xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=ti,phr:<xsl:value-of select="translate(//marc:datafield[@tag=245]/marc:subfield[@code='a'], '.', '')"/></xsl:attribute>
@@ -1028,7 +1058,26 @@
                 </xsl:variable>
             <xsl:choose>
                 <xsl:when test="$UseControlNumber = '1' and marc:subfield[@code='w']">
-                    <a><xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=Control-number:<xsl:call-template name="extractControlNumber"><xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/></xsl:call-template> and cni:<xsl:value-of select="$controlField003"/></xsl:attribute>
+                    <xsl:variable name="f773cn">
+                        <xsl:call-template name="extractControlNumber">
+                            <xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/>
+                        </xsl:call-template>
+                    </xsl:variable>
+                    <xsl:variable name="f773cni">
+                        <xsl:call-template name="extractControlNumberIdentifier">
+                            <xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/>
+                        </xsl:call-template>
+                    </xsl:variable>
+                    <a>
+                        <xsl:choose>
+                            <!-- N.B. The query format has been carefully crafted to work with both Zebra and Elasticsearch... -->
+                            <xsl:when test="$f773cni != ''">
+                                <xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=Control-number,ext:"<xsl:value-of select="str:encode-uri($f773cn, true())"/>" AND cni,ext:"<xsl:value-of select="str:encode-uri($f773cni, true())"/>"</xsl:attribute>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=Control-number,ext:"<xsl:value-of select="str:encode-uri($f773cn, true())"/>" AND cni,ext:"<xsl:value-of select="str:encode-uri($controlField003, true())"/>"</xsl:attribute>
+                            </xsl:otherwise>
+                        </xsl:choose>
                         <xsl:value-of select="translate($f773, '()', '')"/>
                     </a>
                     <xsl:if test="marc:subfield[@code='g']"><xsl:text> </xsl:text><xsl:value-of select="marc:subfield[@code='g']"/></xsl:if>

--- a/koha-tmpl/intranet-tmpl/prog/en/xslt/MARC21slimUtils.xsl
+++ b/koha-tmpl/intranet-tmpl/prog/en/xslt/MARC21slimUtils.xsl
@@ -128,6 +128,24 @@
 	    </xsl:choose>
 	</xsl:template>
 
+	<!-- Function extractControlNumberIdentifier is used to extract the control number identifier from MARC tags 773/80/85 [etc.] subfield $w.
+	     Parameter: control number string.
+	     Assumes LOC convention: (OrgCode)recordNumber.
+	     If OrgCode is not present, return empty string.
+	     Additionally, handle various brackets/parentheses. Chop leading and trailing spaces.
+	-->
+	<xsl:template name="extractControlNumberIdentifier">
+	    <xsl:param name="subfieldW"/>
+	    <xsl:variable name="tranW" select="translate($subfieldW,']})&gt;','))))')"/>
+	    <xsl:choose>
+	      <xsl:when test="contains($tranW,'(') and contains($tranW,')')">
+	        <xsl:value-of select="normalize-space(translate(substring-before(substring-after($tranW,'('), ')'),'[]{}()&lt;&gt;',''))"/>
+	      </xsl:when>
+	      <xsl:otherwise>
+	      </xsl:otherwise>
+	    </xsl:choose>
+	</xsl:template>
+
     <!-- Function m880Select:  Display Alternate Graphic Representation (MARC 880) for selected latin "base"tags
         - should be called immediately before the corresonding latin tags are processed 
         - tags in right-to-left languages are displayed floating right

--- a/koha-tmpl/opac-tmpl/bootstrap/en/xslt/MARC21slim2OPACDetail.xsl
+++ b/koha-tmpl/opac-tmpl/bootstrap/en/xslt/MARC21slim2OPACDetail.xsl
@@ -48,6 +48,7 @@
         <xsl:variable name="leader6" select="substring($leader,7,1)"/>
         <xsl:variable name="leader7" select="substring($leader,8,1)"/>
         <xsl:variable name="leader19" select="substring($leader,20,1)"/>
+        <xsl:variable name="controlField003" select="marc:controlfield[@tag=003]"/>
         <xsl:variable name="controlField008" select="marc:controlfield[@tag=008]"/>
         <xsl:variable name="materialTypeCode">
             <xsl:choose>
@@ -99,61 +100,71 @@
         <!-- Component part records: Displaying title and author of component part records -->
         <xsl:if test="marc:componentPartRecords">
             <span class="results_summary componentPartRecordsContainer">
-                <h5>Component part records:</h5>
+                <h5>Component part records (<a><xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=<xsl:value-of select="str:encode-uri(marc:componentPartSearchQuery, true())"/></xsl:attribute>view all <xsl:value-of select="marc:componentPartRecordCount"/></a>):</h5>
+                <xsl:variable name="componentPartDisplayCount"><xsl:value-of select="count(marc:componentPartRecords/marc:record)"/></xsl:variable>
                 <ol class="componentParts">
                     <xsl:for-each select="marc:componentPartRecords/marc:record">
                         <li>
-                            <span class="componentPartRecord">
-                                <span class="componentPartRecordTitle">
-                                    <a>
-                                    <xsl:attribute name="href">/cgi-bin/koha/opac-detail.pl?biblionumber=<xsl:value-of select="marc:datafield[@tag=999]/marc:subfield[@code='c']" /></xsl:attribute>
-                                    <xsl:choose>
-                                        <xsl:when test="marc:datafield[@tag=245]/marc:subfield[@code='a']">
-                                            <xsl:value-of select="substring-before( concat(marc:datafield[@tag=245]/marc:subfield[@code='a'], '/'), '/')" />
+                            <xsl:choose>
+                                <xsl:when test="position() &lt; $componentPartDisplayCount or $componentPartDisplayCount = //marc:componentPartRecordCount">
+                                    <span class="componentPartRecord">
+                                        <span class="componentPartRecordTitle">
+                                            <a>
+                                            <xsl:attribute name="href">/cgi-bin/koha/opac-detail.pl?biblionumber=<xsl:value-of select="marc:datafield[@tag=999]/marc:subfield[@code='c']" /></xsl:attribute>
+                                            <xsl:choose>
+                                                <xsl:when test="marc:datafield[@tag=245]/marc:subfield[@code='a']">
+                                                    <xsl:value-of select="substring-before( concat(marc:datafield[@tag=245]/marc:subfield[@code='a'], '/'), '/')" />
+                                                </xsl:when>
+                                                <xsl:when test="marc:datafield[@tag=240]/marc:subfield[@code='a']">
+                            <xsl:for-each select="marc:datafield[@tag=240]">
+                                <xsl:call-template name="chopPunctuation">
+                                <xsl:with-param name="chopString">
+                                <xsl:call-template name="subfieldSelect">
+                                <xsl:with-param name="codes">amnp</xsl:with-param>
+                                </xsl:call-template>
+                                </xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:for-each>
+                                                </xsl:when>
+                                                <xsl:when test="marc:datafield[@tag=130]/marc:subfield[@code='a']">
+                            <xsl:for-each select="marc:datafield[@tag=130]">
+                                <xsl:call-template name="chopPunctuation">
+                                <xsl:with-param name="chopString">
+                                <xsl:call-template name="subfieldSelect">
+                                <xsl:with-param name="codes">amnp</xsl:with-param>
+                                </xsl:call-template>
+                                </xsl:with-param>
+                                </xsl:call-template>
+                            </xsl:for-each>
+                                                </xsl:when>
+                                                <xsl:otherwise>
+                                                    <xsl:text>[Record with no title statement]</xsl:text>
+                                                </xsl:otherwise>
+                                            </xsl:choose>
+                                            </a>
+                                        </span>
+                        <xsl:choose>
+                                        <xsl:when test="marc:datafield[@tag=100]/marc:subfield[@code='a']">
+                                            -
+                                            <span class="componentPartRecordAuthor">
+                                                <xsl:value-of select="marc:datafield[@tag=100]/marc:subfield[@code='a']" />
+                                            </span>
                                         </xsl:when>
-                                        <xsl:when test="marc:datafield[@tag=240]/marc:subfield[@code='a']">
-					  <xsl:for-each select="marc:datafield[@tag=240]">
-					    <xsl:call-template name="chopPunctuation">
-					      <xsl:with-param name="chopString">
-						<xsl:call-template name="subfieldSelect">
-						  <xsl:with-param name="codes">amnp</xsl:with-param>
-						</xsl:call-template>
-					      </xsl:with-param>
-					    </xsl:call-template>
-					  </xsl:for-each>
+                                        <xsl:when test="marc:datafield[@tag=110]/marc:subfield[@code='a']">
+                                            -
+                                            <span class="componentPartRecordAuthor">
+                                                <xsl:value-of select="marc:datafield[@tag=110]/marc:subfield[@code='a']" />
+                                            </span>
                                         </xsl:when>
-                                        <xsl:when test="marc:datafield[@tag=130]/marc:subfield[@code='a']">
-					  <xsl:for-each select="marc:datafield[@tag=130]">
-					    <xsl:call-template name="chopPunctuation">
-					      <xsl:with-param name="chopString">
-						<xsl:call-template name="subfieldSelect">
-						  <xsl:with-param name="codes">amnp</xsl:with-param>
-						</xsl:call-template>
-					      </xsl:with-param>
-					    </xsl:call-template>
-					  </xsl:for-each>
-                                        </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:text>[Record with no title statement]</xsl:text>
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                    </a>
-                                </span>
-				<xsl:choose>
-                                  <xsl:when test="marc:datafield[@tag=100]/marc:subfield[@code='a']">
-                                    -
-                                    <span class="componentPartRecordAuthor">
-                                        <xsl:value-of select="marc:datafield[@tag=100]/marc:subfield[@code='a']" />
+                        </xsl:choose>
                                     </span>
-                                  </xsl:when>
-                                  <xsl:when test="marc:datafield[@tag=110]/marc:subfield[@code='a']">
-                                    -
-                                    <span class="componentPartRecordAuthor">
-                                        <xsl:value-of select="marc:datafield[@tag=110]/marc:subfield[@code='a']" />
+                                </xsl:when>
+                                <xsl:when test="position() = $componentPartDisplayCount">
+                                    <span class="componentPartRecordTitle">
+                                        [list truncated - <a><xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=<xsl:value-of select="str:encode-uri(//marc:componentPartSearchQuery, true())"/></xsl:attribute>view all</a>]
                                     </span>
-                                  </xsl:when>
-				</xsl:choose>
-                            </span>
+                                </xsl:when>
+                            </xsl:choose>
                         </li>
                     </xsl:for-each>
                 </ol>
@@ -1105,7 +1116,26 @@
                 </xsl:variable>
             <xsl:choose>
                 <xsl:when test="$UseControlNumber = '1' and marc:subfield[@code='w']">
-                    <a><xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=Control-number:<xsl:call-template name="extractControlNumber"><xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/></xsl:call-template></xsl:attribute>
+                    <xsl:variable name="f773cn">
+                        <xsl:call-template name="extractControlNumber">
+                            <xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/>
+                        </xsl:call-template>
+                    </xsl:variable>
+                    <xsl:variable name="f773cni">
+                        <xsl:call-template name="extractControlNumberIdentifier">
+                            <xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/>
+                        </xsl:call-template>
+                    </xsl:variable>
+                    <a>
+                        <xsl:choose>
+                            <!-- N.B. The query format has been carefully crafted to work with both Zebra and Elasticsearch... -->
+                            <xsl:when test="$f773cni != ''">
+                                <xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=Control-number,ext:"<xsl:value-of select="str:encode-uri($f773cn, true())"/>" AND cni,ext:"<xsl:value-of select="str:encode-uri($f773cni, true())"/>"</xsl:attribute>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=Control-number,ext:"<xsl:value-of select="str:encode-uri($f773cn, true())"/>" AND cni,ext:"<xsl:value-of select="str:encode-uri($controlField003, true())"/>"</xsl:attribute>
+                            </xsl:otherwise>
+                        </xsl:choose>
                         <xsl:value-of select="translate($f773, '()', '')"/>
                     </a>
                     <xsl:if test="marc:subfield[@code='g']"><xsl:text> </xsl:text><xsl:value-of select="marc:subfield[@code='g']"/></xsl:if>

--- a/koha-tmpl/opac-tmpl/bootstrap/en/xslt/MARC21slim2OPACResults.xsl
+++ b/koha-tmpl/opac-tmpl/bootstrap/en/xslt/MARC21slim2OPACResults.xsl
@@ -633,13 +633,27 @@
     <span class="label">Source: </span>
         <xsl:choose>
         <!-- Add a link to the parent record -->
-            <xsl:when test="marc:subfield[@code='w'] and $controlField003">
-                <a>
-                    <xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=Control-number:
-                        <xsl:call-template name="extractControlNumber">
+            <xsl:when test="marc:subfield[@code='w']">
+                <xsl:variable name="f773cn">
+                    <xsl:call-template name="extractControlNumber">
                         <xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/>
-                        </xsl:call-template> and cni:<xsl:value-of select="$controlField003"/>
-                    </xsl:attribute>
+                    </xsl:call-template>
+                </xsl:variable>
+                <xsl:variable name="f773cni">
+                    <xsl:call-template name="extractControlNumberIdentifier">
+                        <xsl:with-param name="subfieldW" select="marc:subfield[@code='w']"/>
+                    </xsl:call-template>
+                </xsl:variable>
+                <a>
+                    <xsl:choose>
+                        <!-- N.B. The query format has been carefully crafted to work with both Zebra and Elasticsearch... -->
+                        <xsl:when test="$f773cni != ''">
+                            <xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=Control-number,ext:"<xsl:value-of select="str:encode-uri($f773cn, true())"/>" AND cni,ext:"<xsl:value-of select="str:encode-uri($f773cni, true())"/>"</xsl:attribute>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=Control-number,ext:"<xsl:value-of select="str:encode-uri($f773cn, true())"/>" AND cni,ext:"<xsl:value-of select="str:encode-uri($controlField003, true())"/>"</xsl:attribute>
+                        </xsl:otherwise>
+                    </xsl:choose>
                     <xsl:value-of select="marc:subfield[@code='t']"/>
                 </a>
             </xsl:when>

--- a/koha-tmpl/opac-tmpl/bootstrap/en/xslt/MARC21slimUtils.xsl
+++ b/koha-tmpl/opac-tmpl/bootstrap/en/xslt/MARC21slimUtils.xsl
@@ -124,6 +124,24 @@
 	    </xsl:choose>
 	</xsl:template>
 
+	<!-- Function extractControlNumberIdentifier is used to extract the control number identifier from MARC tags 773/80/85 [etc.] subfield $w.
+	     Parameter: control number string.
+	     Assumes LOC convention: (OrgCode)recordNumber.
+	     If OrgCode is not present, return empty string.
+	     Additionally, handle various brackets/parentheses. Chop leading and trailing spaces.
+	-->
+	<xsl:template name="extractControlNumberIdentifier">
+	    <xsl:param name="subfieldW"/>
+	    <xsl:variable name="tranW" select="translate($subfieldW,']})&gt;','))))')"/>
+	    <xsl:choose>
+	      <xsl:when test="contains($tranW,'(') and contains($tranW,')')">
+	        <xsl:value-of select="normalize-space(translate(substring-before(substring-after($tranW,'('), ')'),'[]{}()&lt;&gt;',''))"/>
+	      </xsl:when>
+	      <xsl:otherwise>
+	      </xsl:otherwise>
+	    </xsl:choose>
+	</xsl:template>
+
     <!-- Function m880Select:  Display Alternate Graphic Representation (MARC 880) for selected latin "base"tags
         - should be called immediately before the corresonding latin tags are processed
         - tags in right-to-left languages are displayed floating right

--- a/koha-tmpl/opac-tmpl/prog/en/xslt/MARC21slim2OPACDetail.xsl
+++ b/koha-tmpl/opac-tmpl/prog/en/xslt/MARC21slim2OPACDetail.xsl
@@ -123,10 +123,13 @@
 		<!--Component part records: Displaying title and author of component part records if available. These are floated to right by css. -->
 		<xsl:if test="marc:componentPartRecords/marc:componentPart">
 		 <span class="componentPartRecordsContainer results_summary">
-			   <h5>Component part records:</h5>
+               <h5>Component part records (<a><xsl:attribute name="href">/cgi-bin/koha/opac-search.plq=<xsl:value-of select="str:encode-uri(marc:componentPartSearchQuery, true())"/></xsl:attribute>view all <xsl:value-of select="marc:componentPartRecordCount"/></a>):</h5>
+               <xsl:variable name="componentPartDisplayCount"><xsl:value-of select="count(marc:componentPartRecords/marc:record)"/></xsl:variable>
 			   <xsl:for-each select="marc:componentPartRecords/marc:componentPart">
 				 <span class="componentPartRecord">
-						 <span class="componentPartRecordTitle">
+                    <xsl:choose>
+                        <xsl:when test="position() &lt; $componentPartDisplayCount or $componentPartDisplayCount = //marc:componentPartRecordCount">
+							 <span class="componentPartRecordTitle">
 							   <a><xsl:attribute name="href">/cgi-bin/koha/catalogue/detail.pl?biblionumber=<xsl:value-of select="marc:biblionumber" /></xsl:attribute>
 								  <xsl:choose>
 									<xsl:when test="marc:title">
@@ -144,6 +147,13 @@
 							   <xsl:value-of select="marc:author" />
 						 </span>
 					   </xsl:if>
+                    </xsl:when>
+                    <xsl:when test="position() = $componentPartDisplayCount">
+                        <span class="componentPartRecordTitle">
+                            [list truncated - <a><xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=<xsl:value-of select="str:encode-uri(//marc:componentPartSearchQuery, true())"/></xsl:attribute>view all</a>]
+                        </span>
+                    </xsl:when>
+                </xsl:choose>
 				 </span>
 				 <br />
 			   </xsl:for-each>


### PR DESCRIPTION
…ents

PLEASE TEST with Zebra before committing. I've done testing myself, but I'd rather have someone else verify that everything still works properly.

Adds support for linking between host records and component parts with Elasticsearch. Adds also a limit for component parts displayed alongside host record, a link to all components as a result list and linking using 003+001 also when 773w contains (003)001.

REINDEXING IS REQUIRED with the included index configuration changes regardless of whether Zebra or Elasticsearch is used for linking to work properly.

Additionally, QueryAutoTruncate preference must be off with Elasticsearch and UseControlNumber must be on for linking from component parts to their host records to use control number instead of title.