### PR TITLE
KD-3721: (squashme) Fix missing check for on-shelf hold

### DIFF
--- a/Koha/Item/Availability/Hold.pm
+++ b/Koha/Item/Availability/Hold.pm
@@ -231,10 +231,9 @@ sub common_issuing_rule_checks {
         if ($reason = $holdrulecalc->maximum_holds_for_record_reached($params)) {
             $self->unavailable($reason);
         }
-    }
-
-    if ($reason = $holdrulecalc->on_shelf_holds_forbidden) {
-        $self->unavailable($reason);
+        if ($reason = $holdrulecalc->on_shelf_holds_forbidden) {
+            $self->unavailable($reason);
+        }
     }
 
     return $self;


### PR DESCRIPTION
The previous commit didn't take into account whether reserves were allowed at all. This commit takes that into account so that the situation changes as follows:

Previously the condition was:
if there are items available for checkout and on shelf holds are allowed when xxxx

Now:
if there are items available for placing a hold and on shelf holds are allowed when xxxx

This new way in the commit is better in my opinion because we want to ignore those items that couldn't be put on hold anyway. If we don't do it this way then there can be a situation where some biblio cannot be reserved for example because there is a item available for only intra-day loan that nobody really wants to reserve because everybody wants the item that has 28 day loan period. So with this patch in-place we can now put this intra-day loan item to be non-reservable so that it doesn't affect the reservability of 28 day items.