### PR TITLE
Bug 13937: Add a Z39.50 daemon that can inject item status MARC subfi…

### DIFF
--- a/etc/log4perl.conf
+++ b/etc/log4perl.conf
@@ -61,7 +61,7 @@ log4perl.appender.PLACK-ERROR.utf8=1
 
 log4perl.logger.z3950 = WARN, Z3950
 log4perl.appender.Z3950=Log::Log4perl::Appender::File
-log4perl.appender.Z3950.filename=__LOG_DIR__/logs/z3950-error.log
+log4perl.appender.Z3950.filename=__LOG_DIR__/z3950-error.log
 log4perl.appender.Z3950.mode=append
 log4perl.appender.Z3950.layout=PatternLayout
 log4perl.appender.Z3950.layout.ConversionPattern=[%d] [%p] %m %l %n


### PR DESCRIPTION
…elds. Fix log path.

directory _LOG_DIR_/logs does't exists.

All other log4perl -logs are out to _LOG_DIR_

Thank you for the good work Ere!