### PR TITLE
KD-3602: (squashable) fix variable scope problem

### DIFF
--- a/Koha/REST/V1/Borrower.pm
+++ b/Koha/REST/V1/Borrower.pm
@@ -218,7 +218,7 @@ sub status {
         for (qw(EXPIRED CHARGES CREDITS GNA LOST DBARRED NOTES)) {
                 ($flags->{$_}) or next;
                 if ($flags->{$_}->{noissues}) {
-                        my $basic_privileges_ok = 0;
+                        $basic_privileges_ok = 0;
                 }
         }
 


### PR DESCRIPTION
The variable $basic_privileges_ok was only set for the scope of the
for loop but it is supposed to be applied to the variable outside of
the loop.