### PR TITLE
KD-0: Fix koha-plack-daemon.sh syntax error

### DIFF
--- a/misc/bin/koha-plack-daemon.sh
+++ b/misc/bin/koha-plack-daemon.sh
@@ -291,6 +291,7 @@ while [ $# -gt 0 ]; do
             shift ;;
         trace)
             PERL_PARAMS="$PERL_PARAMS -d:Trace"
+            shift ;;
         listen)
             LISTEN="$2"
             shift; shift; ;;


### PR DESCRIPTION
Follow-up to d727f47ae17db52fd7f4da7f74e78c4725428899