### PR TITLE
KD-1645 - Koha database autoinstaller and updater

### DIFF
--- a/C4/Installer.pm
+++ b/C4/Installer.pm
@@ -93,7 +93,7 @@ Installs the Koha database with everything that can be optionally installed, ski
 =cut
 
 sub install_default_database {
-    my ($verbose, $marcflavour) = @_;
+    my ($verbose, $marcflavour, $lang) = @_;
     $marcflavour = 'MARC21' unless $marcflavour;
     my @cc = caller(0);
     require C4::Languages;
@@ -113,7 +113,7 @@ sub install_default_database {
     Koha::AtomicUpdater->new->addAllAtomicUpdates();
 
     my $all_languages = C4::Languages::getAllLanguages();
-    my $lang = 'en';
+    $lang //= 'en';
 
     my @installList;
     my $frameworkList  = $installer->marc_framework_sql_list($lang, $marcflavour);

--- a/installer/install_automatic.pl
+++ b/installer/install_automatic.pl
@@ -11,11 +11,13 @@ use Koha::SearchEngine::Elasticsearch;
 my $help;
 my $verbose;
 my $marcflavour = 'MARC21';
+my $lang = 'en';
 
 GetOptions(
     'h|help'        => \$help,
     'v|verbose'     => \$verbose,
-    'marcflavour=s' => \$marcflavour
+    'marcflavour=s' => \$marcflavour,
+    'lang=s'        => \$lang
 );
 
 if ( $help ) {
@@ -29,6 +31,8 @@ updatedatabase.pl-runs are logged into the Koha logdir
 
   --marcflavour MARC21
 
+  --lang en
+
   -h --help     This nice help
 
 HELP
@@ -36,7 +40,7 @@ HELP
 }
 
 
-C4::Installer::install_default_database($verbose, $marcflavour);
+C4::Installer::install_default_database($verbose, $marcflavour, $lang);
 
 C4::Installer::updatedatabase($verbose);
 


### PR DESCRIPTION
Support default values from other languages

To test:
1. drop database koha; create database koha; exit;
2. perl installer/install_automatic.pl --lang fi-FI
3. Default values from installer/data/mysql/fi-FI should now be included
   (take a look at patron categories, they should be in Finnish)
