### PR TITLE
KD-4043:  Edit and save patrons info with

### DIFF
--- a/members/memberentry.pl
+++ b/members/memberentry.pl
@@ -284,7 +284,7 @@ $newdata{'lang'}    = $input->param('lang')    if defined($input->param('lang'))
 
 # builds default userid
 # userid input text may be empty or missing because of syspref BorrowerUnwantedField
-if ( ( defined $newdata{'userid'} && $newdata{'userid'} eq '' ) || $check_BorrowerUnwantedField =~ /userid/ && !defined $data{'userid'} ) {
+if ( ( defined $newdata{'userid'} && $newdata{'userid'} eq '' ) || $check_BorrowerUnwantedField =~ /userid/ || !defined $data{'userid'} ) {
     if ( ( defined $newdata{'firstname'} ) && ( defined $newdata{'surname'} ) ) {
         # Full page edit, firstname and surname input zones are present
         $newdata{'userid'} = Generate_Userid( $borrowernumber, $newdata{'firstname'}, $newdata{'surname'} );


### PR DESCRIPTION
...edit links

NOTE: This bug is solved in community in Bug 21222.

Patron information couldn't be saved using edit links.
Saving raised error:  'Username/password already exists'.
Fixed logic to generate userid using old data.