### PR TITLE
KD-4004: Don't delete patron with holds

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/en/modules/members/deletemem.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/members/deletemem.tt
@@ -13,7 +13,7 @@
     <div id="yui-main">
     <div class="yui-b">
     [% INCLUDE 'members-toolbar.inc' %]
-    [% IF ( ItemsOnIssues || charges || guarantees ) %]
+    [% IF ( ItemsOnIssues || charges || guarantees || ItemsOnHold) %]
         <div class="dialog alert">
         <h3>Cannot delete patron</h3>
             <ul>
@@ -25,6 +25,9 @@
             [% END %]
             [% IF ( guarantees ) %]
                 <li>Patron's record has guaranteed accounts attached.</li>
+            [% END %]
+            [% IF ( ItemsOnHold ) %]
+                <li>Patron has [% ItemsOnHold %] item(s) on hold.</li>
             [% END %]
             </ul>
     </div>


### PR DESCRIPTION
It was possible to delete patron with holds
and holds didn't leave record in database.

This checks patrons holds and prevents
deleting patron if holds were found.