### PR TITLE
KD-4141-category-timeout. Requires syspref BorrowerCategoryTimeout (y…

### DIFF
--- a/C4/Auth.pm
+++ b/C4/Auth.pm
@@ -27,6 +27,7 @@ use CGI::Session;
 use Scalar::Util qw(blessed);
 use Try::Tiny;
 use YAML::Syck;
+use C4::AuthExtra;
 
 require Exporter;
 use C4::Context;
@@ -156,6 +157,7 @@ More information on the C<gettemplate> sub can be found in the
 Output.pm module.
 
 =cut
+
 
 sub get_template_and_user {
 
@@ -601,6 +603,7 @@ sub get_template_and_user {
         }
     }
 
+
     return ( $template, $borrowernumber, $cookie, $flags );
 }
 
@@ -736,13 +739,13 @@ sub _session_log {
 }
 
 sub _timeout_syspref {
-    my $timeout = C4::Context->preference('timeout') || 600;
-
+   my $timeout = C4::Context->preference('timeout') || 600;
     # value in days, convert in seconds
     if ( $timeout =~ /(\d+)[dD]/ ) {
         $timeout = $1 * 86400;
     }
-    return $timeout;
+   $timeout =  C4::AuthExtra::get_timeout(undef,$timeout);
+   return($timeout);
 }
 
 sub checkauth {
@@ -820,6 +823,11 @@ sub checkauth {
             $ip          = $session->param('ip');
             $lasttime    = $session->param('lasttime');
             $userid      = $s_userid;
+           
+            ###################################
+            $timeout = C4::AuthExtra::get_timeout($userid,$timeout);            
+            ###################################           
+
             $sessiontype = $session->param('sessiontype') || '';
         }
         if ( ( $query->param('koha_login_context') && ( $q_userid ne $s_userid ) )
@@ -1427,6 +1435,11 @@ sub check_api_auth {
             my $ip       = $session->param('ip');
             my $lasttime = $session->param('lasttime');
             my $userid   = $session->param('id');
+            
+            #############################
+            $timeout = C4::AuthExtra::get_timeout($userid,$timeout);
+            ###############################
+
             if ( $lasttime < time() - $timeout ) {
 
                 # time out
@@ -1687,6 +1700,11 @@ sub check_cookie_auth {
         my $ip       = $session->param('ip');
         my $lasttime = $session->param('lasttime');
         my $userid   = $session->param('id');
+
+        ####################################
+        $timeout = C4::AuthExtra::get_timeout($userid,$timeout); 
+        ####################################
+
         if ( $lasttime < time() - $timeout ) {
 
             # time out

--- a/C4/AuthExtra.pm
+++ b/C4/AuthExtra.pm
@@ -1,0 +1,81 @@
+package C4::AuthExtra;
+
+=expl
+get_timeout returns timeout based on user's category
+value is in sysprefs variable BorrowerCategoryTimeout
+value is in yaml-format example:
+
+---
+USERCATEGORY1: 600
+AUTOMAT: 31536000
+
+=cut
+
+use C4::Context;
+use Try::Tiny;
+use YAML;
+
+##################################
+#gets timeout based on borrower's category
+sub get_timeout {
+    my $error;
+    my ($cardnumber,$timeout) = @_;
+    
+    my $dbh   = C4::Context->dbh;
+    my $valueyaml;
+    my $retval = $timeout;
+ 
+    try {
+
+        #get catgorycode
+        my $categorycode = "DEFAULT";
+
+        if ($cardnumber) {
+            $cardnumber = trim($cardnumber);            
+            my $sql="select categorycode from borrowers where trim(cardnumber)='".$cardnumber."'";
+            my $sth=$dbh->prepare($sql);
+            $sth->execute();        
+            while (@row=$sth->fetchrow_array()) {
+                $categorycode=$row[0];
+            }
+            $sth->finish();
+        } 
+        #get timeout's valueyaml from systempreferences
+        $sql="select value from systempreferences where variable='BorrowerCategoryTimeout'";
+        $sth=$dbh->prepare($sql);
+        $sth->execute();
+        while (@row=$sth->fetchrow_array()) {
+            $valueyaml=$row[0];
+        }
+        $sth->finish();
+
+        #get category's timeout
+        my $timeouts=Load($valueyaml);
+        my $newtimeout=$timeouts->{$categorycode};
+        if($newtimeout > 0) {
+            $retval=$newtimeout;
+        }
+    }
+    catch {
+       $error = $_;
+    };
+
+    if($error) {
+        $retval = $timeout;
+    }
+
+    return($retval);
+}
+
+
+##############################################
+sub trim {
+    my ($retval)=@_;
+    $retval =~ s/^\s+|\s+$//g;
+    return($retval);
+}
+
+1;
+
+
+


### PR DESCRIPTION
Requires new syspref BorrowerCategoryTimeout. Value in database must be in yaml format. Value should include timeout for category DEFAULT. 
Example:

---
DEFAULT: 1800
USERCATEGORY1: 600
AUTOMAT: 31536000

This case user's in category USERCATEGORY1 have 10 minutes timeout. 
If syspref BorrowerCategoryTimeout does not exist, timeout gets value of syspref timeout.