### PR TITLE
KD-1892: (squashable) Fix uninitialized value

### DIFF
--- a/misc/cronjobs/iPostEPL/opuscapita_convert_and_send_print_notices.pl
+++ b/misc/cronjobs/iPostEPL/opuscapita_convert_and_send_print_notices.pl
@@ -213,7 +213,7 @@ sub sendletters {
       C4::Context->config('printmailProviders')->{'opuscapita'}->{'sftp'}
       ->{'password'};
 
-    if ( defined $host && defined $user && defined $password ) {
+    if ( $host && $user && $password ) {
         print localtime
           . ": Transferring letters to OpusCapita host $host with SFTP.\n";
         my $status = system(

--- a/misc/cronjobs/iPostEPL/opuscapita_convert_and_send_print_notices.pl
+++ b/misc/cronjobs/iPostEPL/opuscapita_convert_and_send_print_notices.pl
@@ -52,7 +52,7 @@ sub hdiacritic {
 
     my $char;
     my $oldchar;
-    my $retstring;
+    my $retstring = '';
 
     foreach ( split( //, $_[0] ) ) {
         $char    = $_;


### PR DESCRIPTION
Initialize the variable with empty string so it does not fill your
logs with «Use of uninitialized value $retstring in concatenation ...
at .../cronjobs/iPostEPL/opuscapita_convert_and_send_print_notices.pl
line 69» warnings.