### PR TITLE
Fix for KD-543 / 8f1b7b8884 after which only half of the items became added

### DIFF
--- a/C4/Biblio.pm
+++ b/C4/Biblio.pm
@@ -1827,24 +1827,46 @@ descriptions rather than normal ones when they exist.
 sub GetAuthorisedValueDesc {
     my ( $tag, $subfield, $value, $framework, $tagslib, $category, $opac ) = @_;
 
+# DBIC_TRACE=1=/home/koha/nugged/log/trace.log
+
+# my $storage = Koha::Libraries->result_class->result_source->storage;
+# $storage->debug(1);    # start debugging
+# $storage->debugfh(IO::File->new('/home/koha/nugged/log/trace.log', 'w'));
+
     if ( !$category ) {
+
+$NugDebug::ON and NugDebug::timer_delta(201);
 
         return $value unless defined $tagslib->{$tag}->{$subfield}->{'authorised_value'};
 
         #---- branch
         if ( $tagslib->{$tag}->{$subfield}->{'authorised_value'} eq "branches" ) {
-            return Koha::Libraries->find($value)->branchname;
+            my $r = Koha::Libraries->find($value)->branchname;
+
+$NugDebug::ON and NugDebug::timer_delta(202);
+
+            return $r;
         }
 
         #---- itemtypes
         if ( $tagslib->{$tag}->{$subfield}->{'authorised_value'} eq "itemtypes" ) {
             my $itemtype = Koha::ItemTypes->find( $value );
-            return $itemtype ? $itemtype->translated_description : q||;
+
+$NugDebug::ON and NugDebug::timer_delta(203);
+
+            my $r = $itemtype ? $itemtype->translated_description : q||;
+
+$NugDebug::ON and NugDebug::timer_delta(204);
+
+            return $r;
         }
 
         #---- holdings
         if ( $tagslib->{$tag}->{$subfield}->{'authorised_value'} eq "holdings" ) {
             my $holding = Koha::Holdings->find( $value );
+
+$NugDebug::ON and NugDebug::timer_delta(205);
+
             if ( $holding ) {
                 my @parts;
 
@@ -1854,8 +1876,13 @@ sub GetAuthorisedValueDesc {
                 push @parts, $holding->ccode() if $holding->ccode();
                 push @parts, $holding->callnumber() if $holding->callnumber();
 
+$NugDebug::ON and NugDebug::timer_delta(206);
+
                 return join(' ', @parts);
             }
+
+$NugDebug::ON and NugDebug::timer_delta(207);
+
             return q||;
         }
 
@@ -1864,12 +1891,21 @@ sub GetAuthorisedValueDesc {
     }
 
     my $dbh = C4::Context->dbh;
+
+$NugDebug::ON and NugDebug::timer_delta(208);
+
     if ( $category ne "" ) {
         my $sth = $dbh->prepare( "SELECT lib, lib_opac FROM authorised_values WHERE category = ? AND authorised_value = ?" );
         $sth->execute( $category, $value );
         my $data = $sth->fetchrow_hashref;
+
+$NugDebug::ON and NugDebug::timer_delta(209);
+
         return ( $opac && $data->{'lib_opac'} ) ? $data->{'lib_opac'} : $data->{'lib'};
     } else {
+
+$NugDebug::ON and NugDebug::timer_delta(210);
+
         return $value;    # if nothing is found return the original value
     }
 }

--- a/cataloguing/additem.pl
+++ b/cataloguing/additem.pl
@@ -630,7 +630,14 @@ if ($op eq "additem") {
 
             my $exist_itemnumber;
 
-            for (my $i = 0; $i < $number_of_copies; $i++) {
+            my $total_iterations = 0;
+            my $close_to_infinity = 10_000;
+
+            for (my $i = 0; $i < $number_of_copies; $total_iterations++) {
+
+                if( ($total_iterations - $i) > $close_to_infinity ) {
+                    die "Too much iterations ($total_iterations) without adding new items (only $i added): probably system stuck with the same barcode. Aborting to prevent the infinite loop / process hang up.";
+                }
 
                 # If there is a barcode
                 if ($barcodevalue) {
@@ -679,6 +686,7 @@ if ($op eq "additem") {
                     # We count the item only if it was really added
                     # That way, all items are added, even if there was some already existing barcodes
                     # FIXME : Please note that there is a risk of infinite loop here if we never find a suitable barcode
+                    # NOT FIX but possibility to detect issue: ($total_iterations - $i) > $close_to_infinity counter on the beginning of loop.
                     $i++;
                 }
 

--- a/cataloguing/additem.pl
+++ b/cataloguing/additem.pl
@@ -630,14 +630,7 @@ if ($op eq "additem") {
 
             my $exist_itemnumber;
 
-            my $total_iterations = 0;
-            my $close_to_infinity = 10_000;
-
-            for (my $i = 0; $i < $number_of_copies; $total_iterations++) {
-
-                if( ($total_iterations - $i) > $close_to_infinity ) {
-                    die "Too much iterations ($total_iterations) without adding new items (only $i added): probably system stuck with the same barcode. Aborting to prevent the infinite loop / process hang up.";
-                }
+            for (my $i = 0; $i < $number_of_copies; $i++) {
 
                 # If there is a barcode
                 if ($barcodevalue) {
@@ -682,12 +675,6 @@ if ($op eq "additem") {
                         )->store;
 
                     }
-
-                    # We count the item only if it was really added
-                    # That way, all items are added, even if there was some already existing barcodes
-                    # FIXME : Please note that there is a risk of infinite loop here if we never find a suitable barcode
-                    # NOT FIX but possibility to detect issue: ($total_iterations - $i) > $close_to_infinity counter on the beginning of loop.
-                    $i++;
                 }
 
                 # Preparing the next iteration


### PR DESCRIPTION
for some reason, $i++ re-invoked in the 3rd section (no such in KohaCommunity btw) in the for loop, but it also was there as increment if successful adding happened.

Also, there was a reasonable warning that loop might become infinite if it loops over, let's say, the same bar code number returned always,

so at least to detect this error and prevent Perl process from hanging in the infinite loop, I've added another counter to die if it grows too much.

I also created detection that it fails on the big difference between really added and skipped items only. So it can go beyond 10_000 in that loop if almost most of those items added.