### PR TITLE
KD-4000: fix for KD-543 / 8f1b7b8 after which only half of the items became added,

### DIFF
--- a/cataloguing/additem.pl
+++ b/cataloguing/additem.pl
@@ -643,8 +643,13 @@ if ($op eq "additem") {
                     $barcodevalue = $barcodeobj->next_value($oldbarcode) if ($barcodePreference ne 'hbyyyyincr' && ($i > 0 || $exist_itemnumber));
 
                     # Putting it into the record
-                    if ($barcodevalue) {
-                    $record->field($tagfield)->update($tagsubfield => $barcodevalue);
+                    if($barcodevalue) {
+                        $record->field($tagfield)->update( $tagsubfield => $barcodevalue );
+                    }
+                    else {
+                        push @errors, "no_next_barcode";
+                        $itemrecord = $record;
+                        last;
                     }
 
                     # Checking if the barcode already exists
@@ -676,16 +681,12 @@ if ($op eq "additem") {
 
                     }
 
-                    # We count the item only if it was really added
-                    # That way, all items are added, even if there was some already existing barcodes
-                    # FIXME : Please note that there is a risk of infinite loop here if we never find a suitable barcode
-                    $i++;
                 }
 
                 # Preparing the next iteration
                 $oldbarcode = $barcodevalue;
             }
-            undef($itemrecord);
+            undef($itemrecord) if ! @errors;
         }
     }	
     if ($frameworkcode eq 'FA' && $fa_circborrowernumber){


### PR DESCRIPTION
The i++ being in the for clause is sufficient because the $barcodeobj->next_value and C4::Barcodes::ValueBuilder::hbyyyyincr::get_barcode statements return a valid barcode always except when we are out of barcodes. 

Therefore, we can remove the other i++ statement inside the for a loop. In the case where we run out of barcodes, this adds the error "no_next_barcode" to the list of errors.

––-

The previous discussion was in PR https://github.com/KohaSuomi/Koha/pull/113
(also to refer related commits from IRC discussion: https://github.com/KohaSuomi/Koha/commit/8f1b7b88848fd9b0fc767e3ff7dcdc7a56f6ebff, https://github.com/KohaSuomi/kohasuomi/commit/ada6401c2c1e29bf4bb1a33e0153aa041ebac196 )