### PR TITLE
KD-2821: Logrotate improvements

### DIFF
--- a/etc/logrotate.d/koha
+++ b/etc/logrotate.d/koha
@@ -32,6 +32,7 @@ __LOG_DIR__/sip2/*.log
 	su
 	sharedscripts
 	postrotate
+		/__INTRANET_CGI_DIR__/misc/maintenance/anonymize_sip2_log.sh $1
 		/etc/init.d/koha-sip-daemon restart
 	endscript
 }

--- a/etc/logrotate.d/koha
+++ b/etc/logrotate.d/koha
@@ -1,4 +1,5 @@
-__LOG_DIR__/plack*.log
+__LOG_DIR__/plack.log
+__LOG_DIR__/plack-error.log
 __LOG_DIR__/rest.log
 __LOG_DIR__/cpu_pos.log
 {
@@ -19,7 +20,7 @@ __LOG_DIR__/cpu_pos.log
 }
 
 __LOG_DIR__/sip2.log
-__LOG_DIR__/sip2/*
+__LOG_DIR__/sip2/*.log
 {
 	daily
 	missingok
@@ -35,7 +36,9 @@ __LOG_DIR__/sip2/*
 	endscript
 }
 
-__LOG_DIR__/koha-zebradaemon* {
+__LOG_DIR__/koha-zebradaemon-output.log
+__LOG_DIR__/koha-zebradaemon.err
+{
 	daily
 	missingok
 	rotate 14
@@ -61,7 +64,7 @@ __LOG_DIR__/editx/* {
 	su
 }
 
-__LOG_DIR__/cronjobs/* {
+__LOG_DIR__/cronjobs/*.log {
 	daily
 	missingok
 	rotate 14
@@ -85,7 +88,9 @@ __LOG_DIR__/opac-error.log
 	su
 }
 
-__LOG_DIR__/koha-*error_log {
+__LOG_DIR__/koha-error_log
+__LOG_DIR__/koha-opac-error_log
+{
 	daily
 	missingok
 	rotate 14

--- a/etc/logrotate.d/koha
+++ b/etc/logrotate.d/koha
@@ -1,6 +1,6 @@
-__LOG_DIR__/plack*.log 
-__LOG_DIR__/rest.log 
-__LOG_DIR__/cpu_pos.log 
+__LOG_DIR__/plack*.log
+__LOG_DIR__/rest.log
+__LOG_DIR__/cpu_pos.log
 {
 	daily
 	missingok

--- a/misc/maintenance/anonymize_sip2_log.sh
+++ b/misc/maintenance/anonymize_sip2_log.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# This script is only meant to execute under logrotate's prerotate phase
+# See etc/logrotate.d/koha for logrotate configuration
+
+if [ ! "$1" ]; then
+    echo "Usage: anonymize_sip2_log.sh /path/to/sip2.log"
+    exit 1
+fi;
+
+LOG_FILE=$1
+ANONYMIZE_PATRON_DATA="${LOG_FILE}.1"       # sip2.log.1        (absolute path)
+ANONYMIZE_CARDNUMBER="${LOG_FILE}.183.gz"   # sip2.log.183.gz   (absolute path)
+
+if test -e $ANONYMIZE_PATRON_DATA; then
+    cat $ANONYMIZE_PATRON_DATA | perl -pe "s/(ILS::Patron\().*(\): found patron ').*('.*$)/\1***\2***\3/;s/(ILS::Checkout: patron ').*(' has checked out)/\1***\2/;s/(AE|BD|BE|BF|PB|CY|DA).*?\\|/\1***|/g;" > "${ANONYMIZE_PATRON_DATA}.anon";
+    cp -a "${ANONYMIZE_PATRON_DATA}.anon" $ANONYMIZE_PATRON_DATA;
+    rm "${ANONYMIZE_PATRON_DATA}.anon"
+fi;
+if test -e $ANONYMIZE_CARDNUMBER; then
+    cat $ANONYMIZE_CARDNUMBER | gunzip | perl -pe "s/(ILS::Checkout: patron ').*(' has checked out)/\1***\2/;s/(AA).*?\\|/\1***|/g;" | gzip > "${ANONYMIZE_CARDNUMBER}.anon";
+    cp -a "${ANONYMIZE_CARDNUMBER}.anon" $ANONYMIZE_CARDNUMBER;
+    rm "${ANONYMIZE_CARDNUMBER}.anon"
+fi;
+
+exit 0


### PR DESCRIPTION
This PR is a follow up to commit fcb8a12625b18455d171ac90c5d232cd96860b0d

Apparently there has been some issues with logrotate duplicating logfiles exponentially. Perhaps the issue is caused by too loosely defined paths. This PR aims to fix any remaining issues. Logrotate is a must to our production systems due to enormous log size growth (our sip2.log was 29GB:)