### PR TITLE
KD-4059: Make unavailable only waiting holds

### DIFF
--- a/Koha/Item/Availability/Search.pm
+++ b/Koha/Item/Availability/Search.pm
@@ -52,10 +52,11 @@ sub in_opac {
     }
 
     if (!$params->{'ignore_holds'}) {
-        # TODO: Should an item be available in search interface if item is held?
-        # See KD-4059
-        # And commit 0f8be8570c716ea34f83909eb4818cd417fe4e24
-        $self->unavailable($reason) if $reason = $itemcalc->held;
+        if ($reason = $itemcalc->held) {
+            if ($reason->status eq 'Waiting') {
+                $self->unavailable($reason);
+            }
+        }
     }
     if (!$params->{'ignore_transfer'}) {
         $self->unavailable($reason) if $reason = $itemcalc->transfer;


### PR DESCRIPTION
This reflects the reality as held items can be checked out. Only holds
that are in the waiting state (processed, pickup notification sent)
cannot be checked out.