### PR TITLE
KD-2821: (follow-up) Logrotate improvements

### DIFF
--- a/etc/logrotate.d/koha
+++ b/etc/logrotate.d/koha
@@ -32,7 +32,7 @@ __LOG_DIR__/sip2/*.log
 	su
 	sharedscripts
 	postrotate
-		/__INTRANET_CGI_DIR__/misc/maintenance/anonymize_sip2_log.sh $1
+		__INTRANET_CGI_DIR__/misc/maintenance/anonymize_sip2_log.sh $1
 		/etc/init.d/koha-sip-daemon restart
 	endscript
 }
@@ -54,7 +54,7 @@ __LOG_DIR__/koha-zebradaemon.err
 	endscript
 }
 
-__LOG_DIR__/editx/* {
+__LOG_DIR__/editx/*.log {
 	daily
 	missingok
 	rotate 14


### PR DESCRIPTION
Follow-up of https://github.com/KohaSuomi/Koha/pull/116

This commit fixes editx logs path for logrotate

Also removes useless / prefix from sip2 postrotate script path