### PR TITLE
KD-3816: (squashable) Fix atomicupdate error

### DIFF
--- a/installer/data/mysql/atomicupdate/KD-3816-Make-EDItX-use-vendor-edi-accounts.perl
+++ b/installer/data/mysql/atomicupdate/KD-3816-Make-EDItX-use-vendor-edi-accounts.perl
@@ -3,9 +3,9 @@ if( CheckVersion( $DBversion ) ) {
 
     # Make the conversion from procurement_bookseller_link to vendor_edi_accounts if we have old procurement_bookseller_link table
 
-    my $sth_booksellerlink=$dbh->prepare('desc procurement_bookseller_link;');
-    if ( $sth_booksellerlink->execute() ) {
-
+    my $sth_booksellerlink=$dbh->prepare('SHOW TABLES LIKE "procurement_bookseller_link";');
+    $sth_booksellerlink->execute();
+    if ( $sth_booksellerlink->fetch() ) {
         $dbh->do("INSERT INTO vendor_edi_accounts (description, vendor_id, san, id_code_qualifier, transport, orders_enabled) SELECT 'Procurement Bookseller Link', aqbooksellers_id, vendor_assigned_id, '91', 'FILE', '1' FROM procurement_bookseller_link;");
 
         # Then check that it went ok before dropping the old procurement_bookseller_link table


### PR DESCRIPTION
Without this fix we get:

DBD::mysql::st execute failed: Table 'koha.procurement_bookseller_link' doesn't exist [for Statement "desc procurement_bookseller_link;"] at /home/koha/Koha/installer/data/mysql/atomicupdate//KD-3816-Make-EDItX-use-vendor-edi-accounts.perl line 7.