### PR TITLE
Missing follow-ups for bug 13937 

### DIFF
--- a/Koha/Z3950Responder.pm
+++ b/Koha/Z3950Responder.pm
@@ -99,8 +99,11 @@ sub new {
         unshift @{ $self->{yaz_options} }, '-v', 'none,fatal';
     }
 
-    # Set main config for SRU support
-    unshift @{ $self->{yaz_options} }, '-f', $self->{config_dir} . 'config.xml' if $self->{config_dir};
+    # Set main config for SRU support and working directory
+    if ( $self->{config_dir} ) {
+        unshift @{ $self->{yaz_options} }, '-f', $self->{config_dir} . 'config.xml';
+        unshift @{ $self->{yaz_options} }, '-w', $self->{config_dir};
+    }
 
     # Set num to prefetch if not passed
     $self->{num_to_prefetch} //= 20;

--- a/Koha/Z3950Responder/RPN.pm
+++ b/Koha/Z3950Responder/RPN.pm
@@ -45,6 +45,7 @@ sub to_koha {
     my $prefix = '';
     my $suffix = '';
     my $term = $self->{'term'};
+    utf8::decode($term);
 
     if ($attrs) {
         foreach my $attr (@$attrs) {

--- a/Koha/Z3950Responder/Session.pm
+++ b/Koha/Z3950Responder/Session.pm
@@ -23,9 +23,10 @@ use Modern::Perl;
 
 use C4::Circulation qw( GetTransfers );
 use C4::Context;
-use C4::Items qw( GetItem );
 use C4::Reserves qw( GetReserveStatus );
 use C4::Search qw();
+
+use Koha::Items;
 use Koha::Logger;
 
 =head1 NAME
@@ -262,28 +263,28 @@ sub add_item_status {
     my $itemnumber = $field->subfield($itemnumber_subfield);
     next unless $itemnumber;
 
-    my $item = GetItem( $itemnumber );
+    my $item = Koha::Items->find( $itemnumber );
     return unless $item;
 
     my @statuses;
 
-    if ( $item->{onloan} ) {
+    if ( $item->onloan() ) {
         push @statuses, $status_strings->{CHECKED_OUT};
     }
 
-    if ( $item->{itemlost} ) {
+    if ( $item->itemlost() ) {
         push @statuses, $status_strings->{LOST};
     }
 
-    if ( $item->{notforloan} ) {
+    if ( $item->notforloan() ) {
         push @statuses, $status_strings->{NOT_FOR_LOAN};
     }
 
-    if ( $item->{damaged} ) {
+    if ( $item->damaged() ) {
         push @statuses, $status_strings->{DAMAGED};
     }
 
-    if ( $item->{withdrawn} ) {
+    if ( $item->withdrawn() ) {
         push @statuses, $status_strings->{WITHDRAWN};
     }
 

--- a/debian/koha-common.install
+++ b/debian/koha-common.install
@@ -38,4 +38,6 @@ debian/scripts/koha-upgrade-to-3.4          usr/sbin
 debian/scripts/koha-start-sip               usr/sbin
 debian/scripts/koha-stop-sip                usr/sbin
 debian/scripts/koha-enable-sip              usr/sbin
+debian/scripts/koha-z3950-responder         usr/sbin
+debian/scripts/koha-zebra                   usr/sbin
 debian/tmp_docbook/*.8                      usr/share/man/man8

--- a/debian/scripts/koha-functions.sh
+++ b/debian/scripts/koha-functions.sh
@@ -239,6 +239,29 @@ is_z3950_running()
     fi
 }
 
+is_z3950_enabled()
+{
+    local instancename=$1
+
+    if [ -e /etc/koha/sites/$instancename/z3950/config.xml ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+is_z3950_running()
+{
+    local instancename=$1
+
+    if start-stop-daemon --pidfile "/var/run/koha/${instancename}/z3950-responder.pid" \
+            --status ; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 adjust_paths_dev_install()
 {
 # Adjust KOHA_HOME, PERL5LIB for dev installs, as indicated by

--- a/t/db_dependent/Koha/Z3950Responder/GenericSession.t
+++ b/t/db_dependent/Koha/Z3950Responder/GenericSession.t
@@ -1,6 +1,7 @@
 #!/usr/bin/perl
 
 use Modern::Perl;
+use utf8;
 
 use Test::More tests => 3;
 use Test::WWW::Mechanize;
@@ -74,7 +75,7 @@ subtest 'test_search' => sub {
     $search->mock('simple_search_compat', sub {
         my ( $self, $query ) = @_;
 
-        return ('unexpected query', undef, 0) unless $query eq '((author:(author)) AND ((title:(title\(s\))) OR (title:(another))))';
+        return ('unexpected query', undef, 0) unless $query eq '((author:(author)) AND ((title:(title\(s\))) OR (title:(speciäl))))';
 
         my @records = ($marc_record_1, $marc_record_2);
         return (undef, \@records, 2);
@@ -103,7 +104,7 @@ subtest 'test_search' => sub {
     $Zconn->connect('localhost:42111', 0);
     is($Zconn->errcode(), 0, 'Connection is successful: ' . $Zconn->errmsg());
 
-    my $rs = $Zconn->search_pqf('@and @attr 1=1 @attr 4=1 author @or @attr 1=4 title(s) @attr 1=4 another');
+    my $rs = $Zconn->search_pqf('@and @attr 1=1 @attr 4=1 author @or @attr 1=4 title(s) @attr 1=4 speciäl');
     is($Zconn->errcode(), 0, 'Search is successful: ' . $Zconn->errmsg());
 
     is($rs->size(), 2, 'Two results returned');
@@ -132,7 +133,7 @@ subtest 'test_search' => sub {
     @nodes = $dom->getElementsByTagNameNS($ns, 'diagnostics');
     is(scalar(@nodes), 1, 'diagnostics returned for bad query');
 
-    $agent->get_ok("$base/biblios?operation=searchRetrieve&recordSchema=marcxml&version=1.1&maximumRecords=10&query=(dc.author%3dauthor AND (dc.title%3d\"title(s)\" OR dc.title%3danother))", 'Retrieve search results');
+    $agent->get_ok("$base/biblios?operation=searchRetrieve&recordSchema=marcxml&version=1.1&maximumRecords=10&query=(dc.author%3dauthor AND (dc.title%3d\"title(s)\" OR dc.title%3dspeciäl))", 'Retrieve search results');
     $dom = XML::LibXML->load_xml(string => $agent->content());
     @nodes = $dom->getElementsByTagNameNS($ns, 'searchRetrieveResponse');
     is(scalar(@nodes), 1, 'searchRetrieveResponse returned');

--- a/t/db_dependent/Koha/Z3950Responder/GenericSession.t
+++ b/t/db_dependent/Koha/Z3950Responder/GenericSession.t
@@ -20,7 +20,7 @@ our $child;
 
 subtest 'test_search' => sub {
 
-    plan tests => 20;
+    plan tests => 19;
 
     t::lib::Mocks::mock_preference('SearchEngine', 'Elasticsearch');
 
@@ -113,8 +113,6 @@ subtest 'test_search' => sub {
     my $returned2= MARC::Record->new_from_xml($rs->record(1)->raw());
     ok($returned2, 'Record 2 returned as MARCXML');
     is($returned2->as_xml, $marc_record_2->as_xml, 'Record 2 returned properly');
-
-    is($rs->record(2), undef, 'Record 3 does not exist');
 
     # SRU protocol tests
     my $base = 'http://localhost:42111';

--- a/t/db_dependent/Koha/Z3950Responder/Session2.t
+++ b/t/db_dependent/Koha/Z3950Responder/Session2.t
@@ -5,6 +5,8 @@ use Test::More tests => 3;
 use t::lib::TestBuilder;
 use C4::Items;
 
+use Koha::Caches;
+
 BEGIN {
     use_ok('Koha::Z3950Responder');
     use_ok('Koha::Z3950Responder::Session');
@@ -20,7 +22,7 @@ subtest 'add_item_status' => sub {
     plan tests => 2;
 
     # This time we are sustituting some values
-    $builder->schema->resultset( 'AuthorisedValue' )->delete_all;
+    $builder->schema->resultset( 'AuthorisedValue' )->delete_all();
     $builder->build({
         source => 'AuthorisedValue',
         value => {
@@ -37,6 +39,10 @@ subtest 'add_item_status' => sub {
             lib => "Borked completely"
         }
     });
+
+    # Clear the cache to make sure the above values take effect
+    my $cache = Koha::Caches->get_instance();
+    $cache->flush_all();
 
     ## FIRST ITEM HAS ALL THE STATUSES ##
     my $item_1 = $builder->build({

--- a/t/db_dependent/Koha/Z3950Responder/ZebraSession.t
+++ b/t/db_dependent/Koha/Z3950Responder/ZebraSession.t
@@ -18,7 +18,7 @@ our $child;
 
 subtest 'test_search' => sub {
 
-    plan tests => 9;
+    plan tests => 8;
 
     t::lib::Mocks::mock_preference('SearchEngine', 'Zebra');
 
@@ -113,8 +113,6 @@ subtest 'test_search' => sub {
     my $returned2= MARC::Record->new_from_xml($rs->record(1)->raw());
     ok ($returned2, 'Record 2 returned as MARCXML');
     is($returned2->as_xml, $marc_record_2->as_xml, 'Record 2 returned properly');
-
-    is($rs->record(2), undef, 'Record 3 does not exist');
 
     cleanup();
 };

--- a/t/db_dependent/Koha/Z3950Responder/config.xml
+++ b/t/db_dependent/Koha/Z3950Responder/config.xml
@@ -1,0 +1,13 @@
+<yazgfs>
+  <listen id="public">tcp:localhost:42111</listen>
+  <server>
+    <cql2rpn>../../../../etc/z3950/pqf.properties</cql2rpn>
+    <explain xmlns="http://explain.z3950.org/dtd/2.0/">
+      <retrievalinfo>
+        <retrieval syntax="usmarc" name="marc21"/>
+        <retrieval syntax="unimarc" name="unimarc"/>
+        <retrieval syntax="xml" name="marcxml" identifier="info:srw/schema/1/marcxml-v1.1"/>
+      </retrievalinfo>
+    </explain>
+  </server>
+</yazgfs>

--- a/t/db_dependent/Koha/Z3950Responder/config.xml
+++ b/t/db_dependent/Koha/Z3950Responder/config.xml
@@ -1,7 +1,7 @@
 <yazgfs>
   <listen id="public">tcp:localhost:42111</listen>
   <server>
-    <cql2rpn>../../../../etc/z3950/pqf.properties</cql2rpn>
+    <cql2rpn>pqf.properties</cql2rpn>
     <explain xmlns="http://explain.z3950.org/dtd/2.0/">
       <retrievalinfo>
         <retrieval syntax="usmarc" name="marc21"/>

--- a/t/db_dependent/Koha/Z3950Responder/pqf.properties
+++ b/t/db_dependent/Koha/Z3950Responder/pqf.properties
@@ -1,0 +1,162 @@
+#
+# Propeties file to drive org.z3950.zing.cql.CQLNode's toPQF()
+# back-end and the YAZ CQL-to-PQF converter.  This specifies the
+# interpretation of various CQL indexes, relations, etc. in terms
+# of Type-1 query attributes.
+#
+# This configuration file generates queries using BIB-1 attributes.
+# See http://www.loc.gov/z3950/agency/zing/cql/dc-indexes.html
+# for the Maintenance Agency's work-in-progress mapping of Dublin Core
+# indexes to Attribute Architecture (util, XD and BIB-2)
+# attributes.
+
+# Identifiers for prefixes used in this file. (index.*)
+set.cql     = info:srw/cql-context-set/1/cql-v1.1
+set.rec     = info:srw/cql-context-set/2/rec-1.0
+set.dc      = info:srw/cql-context-set/1/dc-v1.1
+set.bath    = http://zing.z3950.org/cql/bath/2.0/
+
+# default set (in query)
+set     = info:srw/cql-context-set/1/dc-v1.1
+
+# The default access point and result-set references
+index.cql.serverChoice = 1=1016
+    # srw.serverChoice is deprecated in favour of cql.serverChoice
+    # BIB-1 "any"
+
+index.rec.id                = 1=12
+index.dc.identifier         = 1=1007
+index.dc.title              = 1=4
+index.dc.subject            = 1=21
+index.dc.creator            = 1=1003
+index.dc.author             = 1=1003
+index.dc.itemtype           = 1=1031
+index.dc.barcode            = 1=1028
+index.dc.branch             = 1=1033
+index.dc.isbn               = 1=7
+index.dc.issn               = 1=8
+index.dc.any                = 1=1016
+index.dc.note               = 1=63
+
+# personal name experimental
+index.dc.pname  = 1=1
+    ### Unofficial synonym for "creator"
+index.dc.editor             = 1=1020
+index.dc.publisher          = 1=1018
+index.dc.description        = 1=62
+    # "abstract"
+index.dc.date               = 1=30
+index.dc.resourceType       = 1=1031
+    # guesswork: "Material-type"
+index.dc.format             = 1=1034
+    # guesswork: "Content-type"
+index.dc.resourceIdentifier = 1=12
+    # "Local number"
+#index.dc.source                = 1=1019
+    # "Record-source"
+index.dc.language           = 1=54
+    # "Code--language"
+
+index.dc.Place-publication  = 1=59
+    # "Place-publication"
+
+#index.dc.relation           = 1=?
+    ### No idea how to represent this
+#index.dc.coverage           = 1=?
+    ### No idea how to represent this
+#index.dc.rights             = 1=?
+    ### No idea how to represent this
+
+# Relation attributes are selected according to the CQL relation by
+# looking up the "relation.<relation>" property:
+#
+relation.<                  = 2=1
+relation.le                 = 2=2
+relation.eq                 = 2=3
+relation.exact              = 2=3
+relation.ge                 = 2=4
+relation.>                  = 2=5
+relation.<>                 = 2=6
+
+### These two are not really right:
+relation.all                = 2=3
+relation.any                = 2=3
+
+# BIB-1 doesn't have a server choice relation, so we just make the
+# choice here, and use equality (which is clearly correct).
+relation.scr                = 2=3
+
+# Relation modifiers.
+#
+relationModifier.relevant   = 2=102
+relationModifier.fuzzy      = 5=103
+    ### 100 is "phonetic", which is not quite the same thing
+relationModifier.stem       = 2=101
+relationModifier.phonetic   = 2=100
+
+# Position attributes may be specified for anchored terms (those
+# beginning with "^", which is stripped) and unanchored (those not
+# beginning with "^").  This may change when we get a BIB-1 truncation
+# attribute that says "do what CQL does".
+#
+position.first              = 3=1 6=1
+    # "first in field"
+position.any                = 3=3 6=1
+    # "any position in field"
+position.last               = 3=4 6=1
+    # not a standard BIB-1 attribute
+position.firstAndLast       = 3=3 6=3
+    # search term is anchored to be complete field
+
+# Structure attributes may be specified for individual relations; a
+# default structure attribute my be specified by the pseudo-relation
+# "*", to be used whenever a relation not listed here occurs.
+#
+structure.exact             = 4=108
+    # string
+structure.all               = 4=2
+structure.any               = 4=2
+structure.*                 = 4=1
+    # phrase
+
+# Truncation attributes used to implement CQL wildcard patterns.  The
+# simpler forms, left, right- and both-truncation will be used for the
+# simplest patterns, so that we produce PQF queries that conform more
+# closely to the Bath Profile.  However, when a more complex pattern
+# such as "foo*bar" is used, we fall back on Z39.58-style masking.
+#
+truncation.right            = 5=1
+truncation.left             = 5=2
+truncation.both             = 5=3
+truncation.none             = 5=100
+truncation.z3958            = 5=104
+
+# Finally, any additional attributes that should always be included
+# with each term can be specified in the "always" property.
+#
+always                      = 6=1
+# 6=1: completeness = incomplete subfield
+
+
+# Bath Profile support, added Thu Dec 18 13:06:20 GMT 2003
+# See the Bath Profile for SRW at
+#   http://zing.z3950.org/cql/bath.html
+# including the Bath Context Set defined within that document.
+#
+# In this file, we only map index-names to BIB-1 use attributes, doing
+# so in accordance with the specifications of the Z39.50 Bath Profile,
+# and leaving the relations, wildcards, etc. to fend for themselves.
+
+index.bath.keyTitle         = 1=33
+index.bath.possessingInstitution    = 1=1044
+index.bath.name             = 1=1002
+index.bath.personalName     = 1=1
+index.bath.corporateName    = 1=2
+index.bath.conferenceName   = 1=3
+index.bath.uniformTitle     = 1=6
+index.bath.isbn             = 1=7
+index.bath.issn             = 1=8
+index.bath.geographicName   = 1=58
+index.bath.notes            = 1=63
+index.bath.topicalSubject   = 1=1079
+index.bath.genreForm        = 1=1075


### PR DESCRIPTION
Here are missing follow-ups for bug 13937. Includes patch which fixes searching with UTF-8 characters.