### PR TITLE
KD-3816: (squashable) Don't abort whole atomicupdate script

### DIFF
--- a/installer/data/mysql/atomicupdate/KD-3816-Make-EDItX-use-vendor-edi-accounts.perl
+++ b/installer/data/mysql/atomicupdate/KD-3816-Make-EDItX-use-vendor-edi-accounts.perl
@@ -32,5 +32,3 @@ if( CheckVersion( $DBversion ) ) {
     SetVersion( $DBversion );
     print "Upgrade to $DBversion done (KD-3816-Make-EDItX-use-vendor-edi-accounts)\n";
 }
-
-exit 0;


### PR DESCRIPTION
Running exit() stopped the whole atomicupdate.pl script therefore the
atomicupdates coming after this one didn't run.