### PR TITLE
KD-1159-5: Pass unblessed Koha::Patron from REST API to C4::SelfService

### DIFF
--- a/Koha/REST/V1/Borrower.pm
+++ b/Koha/REST/V1/Borrower.pm
@@ -263,7 +263,7 @@ sub get_self_service_status {
     try {
         my $patron = Koha::Patrons->cast($c->validation->param('cardnumber'));
         my $branchcode = $c->validation->param('branchcode');
-        C4::SelfService::CheckSelfServicePermission($patron, $branchcode, 'accessMainDoor');
+        C4::SelfService::CheckSelfServicePermission($patron->unblessed, $branchcode, 'accessMainDoor');
         #If we didn't get any exceptions, we succeeded
         $payload = {permission => Mojo::JSON->true};
         return $c->render(status => 200, openapi => $payload);


### PR DESCRIPTION
C4::SelfService is using an unblessed representation of Koha::Patron, however,
the REST API controller was not updated to match this change.

Toveri access control devices are broken without this commit. Please merge it into production branch.