### PR TITLE
KD-4134: Multiple Bibliorecord items adding is very slow: fix 1 of 2

### DIFF
--- a/cataloguing/additem.pl
+++ b/cataloguing/additem.pl
@@ -659,7 +659,7 @@ if ($op eq "additem") {
 
                 # Adding the item
                 if (!$exist_itemnumber) {
-                    my ($oldbiblionumber,$oldbibnum,$oldbibitemnum) = AddItemFromMarc($record,$biblionumber);
+                    my ($oldbiblionumber,$oldbibnum,$oldbibitemnum) = AddItemFromMarc( $record, $biblionumber, $dbh, 1 );
                     set_item_default_location($oldbibitemnum);
 
                     if ($addToPrintLabelsList) {
@@ -687,6 +687,9 @@ if ($op eq "additem") {
                 # Preparing the next iteration
                 $oldbarcode = $barcodevalue;
             }
+
+            ModZebra( $biblionumber, "specialUpdate", "biblioserver" );
+
             undef($itemrecord) if ! @errors;
         }
     }	


### PR DESCRIPTION
Solved:
- call to ModZebra was done after EACH item added,
  but it was called only with main biblionumber only,
  so call was the same on each of requests
- and also time spent in that ModZebra sub increased with every
  next hundred items in DB for that element: so adding every next 100
  was slower and slower,
- now it's called only once (by adding some extra parameter to "AddItem*" sub set in postponed mode
- and now adding of elements not so heavily depends from how much items was in DB before.