### PR TITLE
KD-4134: Multiple Bibliorecord items adding is very slow: fix 2 of 2

### DIFF
--- a/C4/Items.pm
+++ b/C4/Items.pm
@@ -224,7 +224,7 @@ sub ShelfToCart {
 
 =head2 AddItemFromMarc
 
-  my ($biblionumber, $biblioitemnumber, $itemnumber) 
+  my ($biblionumber, $biblioitemnumber, $itemnumber[, $item])
       = AddItemFromMarc($source_item_marc, $biblionumber);
 
 Given a MARC::Record object containing an embedded item
@@ -249,7 +249,7 @@ sub AddItemFromMarc {
 
 =head2 AddItem
 
-  my ($biblionumber, $biblioitemnumber, $itemnumber) 
+  my ($biblionumber, $biblioitemnumber, $itemnumber[, $item])
       = AddItem($item, $biblionumber[, $dbh, $frameworkcode, $unlinked_item_subfields]);
 
 Given a hash containing item column names as keys,
@@ -306,7 +306,7 @@ sub AddItem {
     logaction( "CATALOGUING", "ADD", $itemnumber, "item" )
       if C4::Context->preference("CataloguingLog");
 
-    return ( $item->{biblionumber}, $item->{biblioitemnumber}, $itemnumber );
+    return ( $item->{biblionumber}, $item->{biblioitemnumber}, $itemnumber, $item );
 }
 
 =head2 AddItemBatchFromMarc

--- a/koha-tmpl/intranet-tmpl/prog/en/modules/cataloguing/additem.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/cataloguing/additem.tt
@@ -168,6 +168,13 @@ function confirm_deletion() {
 [% IF ( not_same_branch ) %]<div class="dialog alert"><strong>Cannot delete</strong>: The items do not belong to your library.</div>[% END %]
 [% IF ( linked_analytics ) %]<div class="dialog alert"><strong>Cannot delete</strong>: item has linked <a href="/cgi-bin/koha/catalogue/detail.pl?biblionumber=[% biblionumber %]&amp;analyze=1">analytics.</a>.</div>[% END %]
 
+[% IF ( num_items_added ) %]
+<div class="dialog message">
+    <h3><strong>[% num_items_added %]</strong> item(s) added.</h3>
+    <a href="/cgi-bin/koha/cataloguing/additem.pl?biblionumber=[% biblionumber %]">Return to the added list</a>
+</div>
+[% END %]
+
 <div id="cataloguing_additem_itemlist">
     [% IF ( item_loop ) %]
         <div>
@@ -248,6 +255,7 @@ function confirm_deletion() {
 </div>
 <div class="yui-u">
 <div id="cataloguing_additem_newitem">
+[% IF NOT ( num_items_added ) %]
     <form id="f" method="post" action="/cgi-bin/koha/cataloguing/additem.pl" name="f">
     <input type="hidden" name="op" value="[% op %]" />
     [% IF (popup) %]
@@ -366,6 +374,7 @@ function confirm_deletion() {
 
 
     </form>
+[% END %]
 </div>
 </div><!-- /yui-u -->
 </div><!-- /yui-gf -->


### PR DESCRIPTION
Speeded up loading of post-POST-request page
when big number of items added:

- template doesn't loads all items but just
  shows "XXX items added. Return to the list".
- always available `$item` structure in AddItem returned
  as one extra parameter for not to be re-requested again from DB
- set_item_default_location analyses of location not changed, it
  does not requests DB to be rewritten (why to save same record back?).