### PR TITLE
Bug 15644 - (BACKPORTED) City dropdown default selection when modifying a patron matches only on city

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/en/includes/member-main-address-style-de.inc
+++ b/koha-tmpl/intranet-tmpl/prog/en/includes/member-main-address-style-de.inc
@@ -84,7 +84,7 @@
         <select id="select_city" name="select_city">
             <option value="|||"></option>
             [% FOREACH c IN cities %]
-                [% IF c.city_name == city %]
+                [% IF c.city_name == city && c.city_state == state && c.city_zipcode == zipcode %]
                 <option value="[% c.city_zipcode %]|[% c.city_name %]|[% c.city_state %]|[% c.city_country %]" selected="selected">
                 [% ELSE %]
                 <option value="[% c.city_zipcode %]|[% c.city_name %]|[% c.city_state %]|[% c.city_country %]">

--- a/koha-tmpl/intranet-tmpl/prog/en/includes/member-main-address-style-fr.inc
+++ b/koha-tmpl/intranet-tmpl/prog/en/includes/member-main-address-style-fr.inc
@@ -83,7 +83,7 @@
         <select id="select_city" name="select_city">
             <option value="|||"></option>
         [% FOREACH c IN cities %]
-            [% IF c.city_name == city %]
+            [% IF c.city_name == city && c.city_state == state && c.city_zipcode == zipcode %]
                 <option value="[% c.city_zipcode %]|[% c.city_name %]|[% c.city_state %]|[% c.city_country %]" selected="selected">
             [% ELSE %]
                  <option value="[% c.city_zipcode %]|[% c.city_name %]|[% c.city_state %]|[% c.city_country %]">

--- a/koha-tmpl/intranet-tmpl/prog/en/includes/member-main-address-style-us.inc
+++ b/koha-tmpl/intranet-tmpl/prog/en/includes/member-main-address-style-us.inc
@@ -72,7 +72,7 @@
         <select id="select_city" name="select_city">
             <option value="|||"></option>
             [% FOREACH c IN cities %]
-                [% IF c.city_name == city %]
+                [% IF c.city_name == city && c.city_state == state && c.city_zipcode == zipcode %]
                 <option value="[% c.city_zipcode %]|[% c.city_name %]|[% c.city_state %]|[% c.city_country %]" selected="selected">
                 [% ELSE %]
                 <option value="[% c.city_zipcode %]|[% c.city_name %]|[% c.city_state %]|[% c.city_country %]">


### PR DESCRIPTION
This patch modifies the include files which contain the form fields for
city, state, zipcode, etc. shown on the patron entry screen. The files
are modified so that the city/state/zip <select> preselects a value
based on city, state, and zipcode matching the values in the
corresponding text fields.

To test, confirm that the bug's steps to reproduce are fixed:

- Enter two cities via Administration -> Patrons and circulation
  -> Cities and towns:
    Springfield, MA 01101
    Springfield, VT 05156
- Edit a patron choosing, Springfield VT, and save.
- Edit the patron again and confirm that the correct city is
  pre-selected.
- Confirm this result with all three different settings of the
  "AddressFormat" system preference.

Signed-off-by: Amit Gupta <amit.gupta@informaticsglobal.com>

Signed-off-by: Nick Clemens <nick@bywatersolutions.com>