### PR TITLE
Backport elasticsearch fixes

### DIFF
--- a/Koha/SearchEngine/Elasticsearch.pm
+++ b/Koha/SearchEngine/Elasticsearch.pm
@@ -378,12 +378,7 @@ sub _process_mappings {
                 $options->{property} => $_data
             }
         }
-        # For sort fields, index only a single field with concatenated values
-        if ($sort && @{$record_document->{$target}}) {
-            @{$record_document->{$target}}[0] .= " $_data";
-        } else {
-            push @{$record_document->{$target}}, $_data;
-        }
+        push @{$record_document->{$target}}, $_data;
     }
 }
 
@@ -512,6 +507,20 @@ sub marc_records_to_documents {
                     }
                 }
                 $record_document->{$field} = \@isbns;
+            }
+        }
+
+        # Remove duplicate values and collapse sort fields
+        foreach my $field (keys %{$record_document}) {
+            if (ref($record_document->{$field}) eq 'ARRAY') {
+                @{$record_document->{$field}} = do {
+                    my %seen;
+                    grep { !$seen{ref($_) eq 'HASH' && defined $_->{input} ? $_->{input} : $_}++ } @{$record_document->{$field}};
+                };
+                if ($field =~ /__sort$/) {
+                    # Make sure to keep the sort field length sensible. 255 was chosen as a nice round value.
+                    $record_document->{$field} = [substr(join(' ', @{$record_document->{$field}}), 0, 255)];
+                }
             }
         }
 

--- a/Koha/SearchEngine/Elasticsearch/Indexer.pm
+++ b/Koha/SearchEngine/Elasticsearch/Indexer.pm
@@ -128,15 +128,15 @@ sub update_index {
         };
         push @body, $document;
     }
+    my $response;
     if (@body) {
-        my $response = $elasticsearch->bulk(
+        $response = $elasticsearch->bulk(
             index => $conf->{index_name},
             type => 'data', # is just hard coded in Indexer.pm?
             body => \@body
         );
     }
-    # TODO: handle response
-    return 1;
+    return $response;
 }
 
 =head2 set_index_status_ok

--- a/admin/searchengine/elasticsearch/mappings.yaml
+++ b/admin/searchengine/elasticsearch/mappings.yaml
@@ -1997,17 +1997,17 @@ biblios:
       - facet: '1'
         marc_field: 952b
         marc_type: marc21
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: '1'
         marc_field: 952b
         marc_type: normarc
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: ''
         marc_field: 995c
         marc_type: unimarc
-        sort: ~
+        sort: 0
         suggestible: ''
     type: string
   homebranch:
@@ -2016,17 +2016,17 @@ biblios:
       - facet: '1'
         marc_field: 952a
         marc_type: marc21
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: '1'
         marc_field: 952a
         marc_type: normarc
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: '1'
         marc_field: 995b
         marc_type: unimarc
-        sort: ~
+        sort: 0
         suggestible: ''
     type: string
   host-item:
@@ -2247,17 +2247,17 @@ biblios:
       - facet: ''
         marc_field: '9529'
         marc_type: marc21
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: ''
         marc_field: '9529'
         marc_type: normarc
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: ''
         marc_field: '9959'
         marc_type: unimarc
-        sort: ~
+        sort: 0
         suggestible: ''
     type: number
   itemtype:
@@ -2678,22 +2678,22 @@ biblios:
       - facet: ''
         marc_field: 952o
         marc_type: marc21
-        sort: ~
+        sort: 0
         suggestible: '1'
       - facet: ''
         marc_field: 952o
         marc_type: normarc
-        sort: ~
+        sort: 0
         suggestible: '1'
       - facet: ''
         marc_field: '686'
         marc_type: unimarc
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: ''
         marc_field: 995k
         marc_type: unimarc
-        sort: ~
+        sort: 0
         suggestible: '1'
     type: ''
   local-number:
@@ -2702,17 +2702,17 @@ biblios:
       - facet: ''
         marc_field: 999c
         marc_type: marc21
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: ''
         marc_field: 999c
         marc_type: normarc
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: ''
         marc_field: '001'
         marc_type: unimarc
-        sort: ~
+        sort: 0
         suggestible: ''
     type: string
   location:
@@ -2721,17 +2721,17 @@ biblios:
       - facet: '1'
         marc_field: 952c
         marc_type: marc21
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: '1'
         marc_field: 952c
         marc_type: normarc
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: '1'
         marc_field: 995e
         marc_type: unimarc
-        sort: ~
+        sort: 0
         suggestible: ''
     type: ''
   lost:
@@ -2873,7 +2873,7 @@ biblios:
       - facet: ''
         marc_field: '700'
         marc_type: marc21
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: ''
         marc_field: '710'
@@ -3000,7 +3000,7 @@ biblios:
       - facet: ''
         marc_field: '060'
         marc_type: marc21
-        sort: ~
+        sort: 0
         suggestible: ''
     type: ''
   not-onloan-count:
@@ -3042,17 +3042,17 @@ biblios:
       - facet: 0
         marc_field: '9527'
         marc_type: marc21
-        sort: ~
+        sort: 0
         suggestible: 0
       - facet: 0
         marc_field: '9527'
         marc_type: normarc
-        sort: ~
+        sort: 0
         suggestible: 0
       - facet: 0
         marc_field: 995o
         marc_type: unimarc
-        sort: ~
+        sort: 0
         suggestible: 0
     type: number
   number-db:
@@ -3116,17 +3116,17 @@ biblios:
       - facet: ''
         marc_field: 952q
         marc_type: marc21
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: ''
         marc_field: 952q
         marc_type: normarc
-        sort: ~
+        sort: 0
         suggestible: ''
       - facet: ''
         marc_field: 995n
         marc_type: unimarc
-        sort: ~
+        sort: 0
         suggestible: ''
     type: boolean
   other-control-number:

--- a/misc/search_tools/rebuild_elastic_search.pl
+++ b/misc/search_tools/rebuild_elastic_search.pl
@@ -200,6 +200,8 @@ if ($slice_index == 0) {
     }
 }
 
+=head1 INTERNAL METHODS
+
 =head2 _verify_index_state
 
     _verify_index_state($Koha::SearchEngine::Elasticsearch::BIBLIOS_INDEX, 1);
@@ -235,6 +237,7 @@ sub _verify_index_state {
     _do_reindex($callback, $Koha::SearchEngine::Elasticsearch::BIBLIOS_INDEX);
 
 Does the actual reindexing. $callback is a function that always returns the next record.
+For each index we iterate through the records, committing at specified count
 
 =cut
 
@@ -260,7 +263,8 @@ sub _do_reindex {
         push @commit_buffer, $record;
         if ( !( --$commit_count ) ) {
             _log( 1, "Committing $commit records...\n" );
-            $indexer->update_index( \@id_buffer, \@commit_buffer );
+            my $response = $indexer->update_index( \@id_buffer, \@commit_buffer );
+            _handle_response($response);
             $commit_count  = $commit;
             @id_buffer     = ();
             @commit_buffer = ();
@@ -270,7 +274,8 @@ sub _do_reindex {
 
     # There are probably uncommitted records
     _log( 1, "Committing final records...\n" );
-    $indexer->update_index( \@id_buffer, \@commit_buffer );
+    my $response = $indexer->update_index( \@id_buffer, \@commit_buffer );
+    _handle_response($response);
     _log( 1, "Total $count records indexed\n" );
 }
 
@@ -286,6 +291,27 @@ sub _sanity_check {
     # Do we have an elasticsearch block defined?
     my $conf = C4::Context->config('elasticsearch');
     die "No 'elasticsearch' block is defined in koha-conf.xml.\n" if ( !$conf );
+}
+
+=head2 _handle_response
+
+Parse the return from update_index and display errors depending on verbosity of the script
+
+=cut
+
+sub _handle_response {
+    my ($response) = @_;
+    if( $response->{errors} eq 'true' ){
+        _log( 1, "There were errors during indexing\n" );
+        if ( $verbose > 1 ){
+            foreach my $item (@{$response->{items}}){
+                next unless defined $item->{index}->{error};
+                print "Record #" . $item->{index}->{_id} . " " .
+                      $item->{index}->{error}->{reason} . " (" . $item->{index}->{error}->{type} . ") : " .
+                      $item->{index}->{error}->{caused_by}->{type} . " (" . $item->{index}->{error}->{caused_by}->{reason} . ")\n";
+            }
+        }
+    }
 }
 
 =head2 _log


### PR DESCRIPTION
The first commit shows during indexing if there was an error with indexing a record, as previously it was a silent failure. The second one fixes indexing for records that have hundreds or more items in them.