### PR TITLE
KD-4229: Fix broken details page with Elasticsearch search engine

### DIFF
--- a/admin/searchengine/elasticsearch/mappings.yaml
+++ b/admin/searchengine/elasticsearch/mappings.yaml
@@ -2702,17 +2702,17 @@ biblios:
       - facet: ''
         marc_field: 999c
         marc_type: marc21
-        sort: 0
+        sort: ~
         suggestible: ''
       - facet: ''
         marc_field: 999c
         marc_type: normarc
-        sort: 0
+        sort: ~
         suggestible: ''
       - facet: ''
         marc_field: '001'
         marc_type: unimarc
-        sort: 0
+        sort: ~
         suggestible: ''
     type: string
   location:


### PR DESCRIPTION
The /cgi-bin/koha/catalogue/detail.pl page would not open because of
this error:

No mapping found for [local-number__sort.phrase] in order to sort on

This makes local-number search field sortable and fixes the issue.