### PR TITLE
Bug 13799: (Koha-Suomi follow-up) Authenticate via Authorization header

### DIFF
--- a/Koha/REST/V1/Auth.pm
+++ b/Koha/REST/V1/Auth.pm
@@ -355,10 +355,7 @@ sub _header_auth {
     my ($c, $authorization) = @_;
 
     try {
-        return Koha::Auth::authenticate(
-            $c, $authorization->{'permissions'},
-            { authnotrequired => defined $authorization ? 0 : 1 }
-        );
+        return Koha::Auth::authenticate($c);
     }
     catch {
         my $e = $_;


### PR DESCRIPTION
Authentication via Authorization header fails for requests via "allow-owner" functionality. This is because the current header authentication is set to check permissions before "allow-owner" flag and return a 403 if patron does not have required permissions.

Skip permission checking in _header_auth and check only authentication.
Authorization aka permission checking is done in authenticate_api_request.