### PR TITLE
KD-3172: Acquisition bugfix

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/en/modules/acqui/tables/pendingorders_results.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/acqui/tables/pendingorders_results.tt
@@ -21,7 +21,7 @@
                     "<a href=\"neworderempty.pl?ordernumber=[% loop_order.ordernumber %]&amp;booksellerid=[% loop_order.booksellerid %]\">[% loop_order.ordernumber %]</a>",
                 "dt_summary":
                     "<a href=\"/cgi-bin/koha/catalogue/detail.pl?biblionumber=[% loop_order.biblionumber %]\">[% loop_order.title |html %]</a>
-                [%- IF ( loop_order.author ) %] by [% loop_order.author %][% END -%]
+                [%- IF ( loop_order.author ) %] by [% loop_order.author | html %][% END -%]
                 [%- IF ( loop_order.isbn ) %] &ndash; [% loop_order.isbn %][% END -%]
                 [%- IF ( loop_order.publishercode ) -%]
 <br />Publisher: [% loop_order.publishercode -%]
@@ -30,7 +30,7 @@
                     [%- END -%]
                 [%- END -%]
                 [%- IF ( loop_order.suggestionid ) -%]
-<br/>Suggested by: [% loop_order.surnamesuggestedby %][% IF ( loop_order.firstnamesuggestedby ) %], [% loop_order.firstnamesuggestedby %] [% END -%]
+<br/>Suggested by: [% loop_order.surnamesuggestedby | html %][% IF ( loop_order.firstnamesuggestedby ) %], [% loop_order.firstnamesuggestedby | html %] [% END -%]
 (<a href=\"/cgi-bin/koha/suggestion/suggestion.pl?suggestionid=[% loop_order.suggestionid %]&amp;op=show\">suggestion #[% loop_order.suggestionid %]</a>)
                 [%- END -%]
 <br />

--- a/svc/orders/search
+++ b/svc/orders/search
@@ -71,7 +71,7 @@ my $total_tax_excluded = 0;
 my $total_tax_included = 0;
 
 
-my $countpendings;
+my $countpendings = 0;
 
 my @loop_orders = ();
 unless( defined $invoice->{closedate} ) {


### PR DESCRIPTION
Fix breakage by HTML-encoding the author name if the acq author
contained characters that broke the JSON.

Also fix JSON breakage if order had no lines attached.

Signed-off-by: Pasi Kallinen <pasi.kallinen@koha-suomi.fi>