### PR TITLE
Bug 24185:  'If all unavailable' state for 'on shelf holds' makes holds page very slow if there's a lot of items

### DIFF
--- a/reserve/request.pl
+++ b/reserve/request.pl
@@ -360,6 +360,10 @@ foreach my $biblionumber (@biblionumbers) {
                 $itemtypes->{ $biblioitem->{itemtype} }{imageurl} );
         }
 
+        # this is hash cache for "if any unavailable" on-shelf holds check
+        # in IsAvailableForItemLevelRequest sub should persist outside from the loop
+        my %caches_avail_item_level;
+
         foreach my $itemnumber ( @{ $itemnumbers_of_biblioitem{$biblioitemnumber} } )    {
             my $item = $iteminfos_of->{$itemnumber};
 
@@ -469,8 +473,8 @@ foreach my $biblionumber (@biblionumbers) {
                 if (
                        !$item->{cantreserve}
                     && !$exceeded_maxreserves
-                    && IsAvailableForItemLevelRequest($item, $borrowerinfo)
                     && $can_item_be_reserved eq 'OK'
+                    && IsAvailableForItemLevelRequest($item, $borrowerinfo, \%caches_avail_item_level)
                   )
                 {
                     $item->{available} = 1;


### PR DESCRIPTION
first commit: (already existing KohaCommunity changes adopted to KohaSuomi branch):
Added check for "if $borrowerinfo" to skip requesting holds list when empty search form loaded for first time, same like it NOW done in master in KohaCommunity.

second commit: (changes proposed in ticket for KhoaCommunity):

When "reserve/request.pl -> C4/Reserves.pm::IsAvailableForItemLevelRequest" called many times with hundred of items and "on shelf holds" parameter set to "If all unavailable" for these items+patron, it goes very slow.

This happens because in subloop there is re-checking if all other items unavailable so it is O(n^2) and it re-checks each time the same info for each item with repeating DB/data requests, these two:
  - IsItemOnHoldAndFound (per item)
  - notforloan (per item)

Fix: Use in-variable cache in upper-level subroutine before entering the first "items" loop and passing that hash reference down into subs to cache these three values by keys per-item and per-item-type.

It is simplest way to make it fast without re-thinking pretty complicated whole algorithm and business logic, and, when tested by speed it gave big improvement in execution time.
Also "$can_item_be_reserved->{status} eq 'OK'" moved in "&&" before IsAvailableForItemLevelRequest call to cut away if it false before calling to subroutine.

How to reproduce:

1) have or create/import one book,
record that biblionumber for later use it in down below,

2) add 100 items for that book for some library,

3) find some patron, that patron's card number we will
use as a borrower down below to open holds page,

4) check for the rule or set up single circulation rule
in admin "/cgi-bin/koha/admin/smart-rules.pl",
so that rule will match above book items/library/patron,
check that rule to have non-zero number of holds (total, daily, count) allowed,
and, IMPORTANT: set up "On shelf holds allowed" to "If all unavailable",
("item level holds" doesn't matter).

5) open "Home > Catalog > THAT_BOOK > Place a hold on THAT_BOOK" page
("holds" tab), and enter patron code in the search field,
or you can use direct link, for example in my case it was:
/cgi-bin/koha/reserve/request.pl?biblionumber=4&findborrower=23529000686353

6) it should be pretty long page generation time.

I tested on my computer in VirtualBox for this page generation times,
(stats below is for many runs and smallest value taken from similar in a repetition)

**(not buggy clause, just example how it fast when it not enters that "subloop"):**
*** "On shelf holds allowed" **!=** "If all unavailable":
  100 items:  4.2 seconds,
  200 items:  6.7 seconds,
  300 items:  9.1 seconds,

**(buggy clause):**
*** "On shelf holds allowed" == "If all unavailable":
  100 items:    29 seconds,
  200 items:   1.7 minutes,
  300 items:   3.9 minutes,

**(buggy fixed with caching in hash clause):**
*** "On shelf holds allowed" == "If all unavailable" with cache:
  100 items:  6.5 seconds,
  200 items:   15 seconds,
  300 items:   27 seconds,

Upper last one block with times with this in-var-cache solution.




