### PR TITLE
KD-4277: REST API support for extended patron attributes

### DIFF
--- a/Koha/REST/V1/Patron/Attribute.pm
+++ b/Koha/REST/V1/Patron/Attribute.pm
@@ -1,0 +1,78 @@
+package Koha::REST::V1::Patron::Attribute;
+
+# This file is part of Koha.
+#
+# Koha is free software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# Koha is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with Koha; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use Modern::Perl;
+
+use Mojo::Base 'Mojolicious::Controller';
+use C4::Context;
+use Koha::Exceptions;
+use Koha::Exceptions::Password;
+use Koha::Exceptions::Patron::Attribute;
+use Koha::Patrons;
+use Koha::Patron::Attributes;
+use Scalar::Util qw(blessed looks_like_number);
+use Try::Tiny;
+
+sub list {
+    my $c = shift->openapi->valid_input or return;
+
+    my $params = $c->req->query_params->to_hash;
+
+    if ($params->{code} && $params->{attribute}) {
+        my $attribute_search = { code => $params->{code}, attribute => $params->{attribute} };
+        my $found_attributes = Koha::Patron::Attributes->search($attribute_search);
+        my @borrowernumbers = $found_attributes->get_column("borrowernumber");
+
+        if (@borrowernumbers != 0) {
+            my $patron_search->{"borrowernumber"} = [ @borrowernumbers ];
+            my $matching_patrons = Koha::Patrons->search($patron_search);
+            return $c->render(status => 200, openapi => $matching_patrons);
+        }
+        else {
+            return $c->render(status => 200, openapi => []);
+        }
+    }
+    else {
+        return $c->render(status => 400, openapi => { error => "Missing 'code' or 'attribute' parameter" });
+    }
+}
+
+sub add {
+    my $c = shift->openapi->valid_input or return;
+
+    my $body = $c->req->json;
+    my $attribute_data = { borrowernumber => $body->{borrowernumber}, code => $body->{code}, attribute => $body->{attribute} };
+
+    return try {
+        my $attribute = Koha::Patron::Attribute->new($attribute_data)
+            ->store;
+        return $c->render(status => 201, openapi => $attribute);
+    }
+    catch {
+        if ($_->isa('Koha::Exceptions::Patron::Attribute::NonRepeatable')) {
+            return $c->render(status => 409, openapi => { error => $_->description });
+        }
+
+        if ($_->isa('Koha::Exceptions::Patron::Attribute::UniqueIDConstraint')) {
+            return $c->render(status => 409, openapi => { error => $_->description });
+        }
+        #Koha::Exceptions::rethrow_exception($_);
+        return $c->render(status => 500, openapi => { error => "Attribute not added: $@ $_" });
+    };
+}
+
+1;

--- a/api/v1/swagger/definitions.json
+++ b/api/v1/swagger/definitions.json
@@ -41,6 +41,9 @@
   "patronstatus": {
     "$ref": "definitions/patronstatus.json"
   },
+  "patronattribute": {
+    "$ref": "definitions/patronattribute.json"
+  },
   "session": {
     "$ref": "definitions/session.json"
   },

--- a/api/v1/swagger/definitions/patronattribute.json
+++ b/api/v1/swagger/definitions/patronattribute.json
@@ -1,0 +1,27 @@
+{
+  "type": "object",
+  "properties": {
+    "borrowernumber": {
+      "$ref": "../x-primitives.json#/borrowernumber"
+    },
+    "code": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "attribute code/key"
+    },
+    "attribute": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "attribute value"
+    }
+  },
+  "required": [
+    "borrowernumber",
+    "code",
+    "attribute"
+  ]
+}

--- a/api/v1/swagger/paths.json
+++ b/api/v1/swagger/paths.json
@@ -191,6 +191,9 @@
   "/patrons/alldata": {
     "$ref": "paths/patrons.json#/~1patrons~1alldata"
   },
+  "/patrons/attributes": {
+      "$ref": "paths/patrons.json#/~1patrons~1attributes"
+  },
   "/payments/transaction/{invoicenumber}": {
     "$ref": "paths/payments/transactions.json#/~1payments~1transactions~1{invoicenumber}"
   },

--- a/api/v1/swagger/paths/patrons.json
+++ b/api/v1/swagger/paths/patrons.json
@@ -1351,5 +1351,155 @@
         }
       }
     }
+  },
+  "/patrons/attributes": {
+    "get": {
+      "x-mojo-to": "Patron::Attribute#list",
+      "operationId": "searchPatronsByAttribute",
+      "description": "Searches patrons by extended patron attribute code and value",
+      "produces": [
+        "application/json"
+      ],
+      "parameters": [
+        {
+          "name": "code",
+          "in": "query",
+          "description": "patron attribute code to search by",
+          "required": true,
+          "type": "string"
+        },
+        {
+          "name": "attribute",
+          "in": "query",
+          "description": "attribute value to search for",
+          "required": true,
+          "type": "string"
+        }
+      ],
+      "tags": [
+        "patrons"
+      ],
+      "x-koha-authorization": {
+        "permissions": {
+          "borrowers": "view_borrowers"
+        }
+      },
+      "responses": {
+        "200": {
+          "description": "A list of patrons",
+          "schema": {
+            "type": "array",
+            "items": {
+              "$ref": "../definitions.json#/patron"
+            }
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal server error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      }
+    },
+    "post": {
+      "x-mojo-to": "Patron::Attribute#add",
+      "operationId": "addPatronAttribute",
+      "tags": [
+        "patrons"
+      ],
+      "parameters": [
+        {
+          "name": "body",
+          "in": "body",
+          "description": "A JSON object containing information about the new patron attribute",
+          "required": true,
+          "schema": {
+            "$ref": "../definitions.json#/patronattribute"
+          }
+        }
+      ],
+      "consumes": [
+        "application/json"
+      ],
+      "produces": [
+        "application/json"
+      ],
+      "responses": {
+        "201": {
+          "description": "A successfully set patron attribute",
+          "schema": {
+            "items": {
+              "$ref": "../definitions.json#/patronattribute"
+            }
+          }
+        },
+        "400": {
+          "description": "Bad parameter",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "401": {
+          "description": "Authentication required",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "403": {
+          "description": "Access forbidden",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "404": {
+          "description": "Resource not found",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "409": {
+          "description": "Conflict in creating resource",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "500": {
+          "description": "Internal error",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        },
+        "503": {
+          "description": "Under maintenance",
+          "schema": {
+            "$ref": "../definitions.json#/error"
+          }
+        }
+      },
+      "x-koha-authorization": {
+        "permissions": {
+          "borrowers": "1"
+        }
+      }
+    }
   }
 }

--- a/t/db_dependent/api/v1/patronsattributes.t
+++ b/t/db_dependent/api/v1/patronsattributes.t
@@ -1,0 +1,296 @@
+#!/usr/bin/env perl
+
+# This file is part of Koha.
+#
+# Koha is free software; you can redistribute it and/or modify it under the
+# terms of the GNU General Public License as published by the Free Software
+# Foundation; either version 3 of the License, or (at your option) any later
+# version.
+#
+# Koha is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with Koha; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+use Modern::Perl;
+
+use Test::More tests => 47;
+use Test::Mojo;
+use t::lib::Mocks;
+use t::lib::TestBuilder;
+
+use C4::Auth;
+use C4::Context;
+
+use Koha::AuthUtils;
+use Koha::Database;
+use Koha::Patron;
+use Koha::Patron::Attributes;
+use Koha::Patron::Attribute;
+
+BEGIN {
+    use_ok('Koha::Object');
+    use_ok('Koha::Patron');
+    use_ok('Koha::Patron::Attributes');
+}
+
+t::lib::Mocks::mock_preference('SessionStorage', 'tmp');
+
+my $builder = t::lib::TestBuilder->new();
+my $dbh = C4::Context->dbh;
+my $schema = Koha::Database->schema;
+
+$ENV{REMOTE_ADDR} = '127.0.0.1';
+my $t = Test::Mojo->new('Koha::REST::V1');
+
+$schema->storage->txn_begin;
+
+my $categorycode = $builder->build({ source => 'Category', value => { passwordpolicy => '' } })->{ categorycode };
+my $branchcode = $builder->build({ source => 'Branch' })->{ branchcode };
+my $password = "secret";
+my $patron = $builder->build({
+    source => 'Borrower',
+    value  => {
+        branchcode    => $branchcode,
+        categorycode  => $categorycode,
+        flags         => 0,
+        lost          => 0,
+        gonenoaddress => 0,
+        password      => Koha::AuthUtils::hash_password($password),
+        email         => 'nobody@example.com',
+        emailpro      => 'nobody@example.com',
+        B_email       => 'nobody@example.com',
+    }
+});
+
+my $patron_attribute_type = $builder->build({
+    source => 'BorrowerAttributeType',
+    value  => {
+        code      => "testcode",
+        unique_id => 0,
+        repeatable => 0
+    }
+});
+
+Koha::Patron::Attribute->new({ borrowernumber => $patron->{borrowernumber}, code => "testcode", attribute => 'testval' })
+    ->store();
+
+my $librarian = $builder->build({
+    source => 'Borrower',
+    value  => {
+        branchcode   => $branchcode,
+        categorycode => $categorycode,
+        lost         => 0,
+        password     => Koha::AuthUtils::hash_password("test"),
+        othernames   => 'librarian_othernames',
+    }
+});
+
+Koha::Auth::PermissionManager->grantPermissions({
+    $librarian->{borrowernumber}, {
+    borrowers => 'view_borrowers'
+}
+});
+
+my $valid_params = 'code=testcode&attribute=testval';
+
+
+### GET /api/v1/patrons/attributes
+
+## should require authentication
+$t->get_ok('/api/v1/patrons/attributes?' . $valid_params)
+    ->status_is(401);
+
+
+## should require view_borrowers permission
+my $session = C4::Auth::get_session('');
+$session->param('number', $librarian->{ borrowernumber });
+$session->param('id', $librarian->{ userid });
+$session->param('ip', '127.0.0.1');
+$session->param('lasttime', time());
+$session->flush;
+
+my $tx = $t->ua->build_tx(GET => '/api/v1/patrons/attributes?' . $valid_params);
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(403)
+    ->json_is('/required_permissions', { "borrowers" => "view_borrowers" });
+
+Koha::Auth::PermissionManager->grantAllSubpermissions(
+    $librarian->{borrowernumber}, 'borrowers'
+);
+
+## should require both attribute code and value query parameters
+$tx = $t->ua->build_tx(GET => "/api/v1/patrons/attributes");
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)->status_is(400);
+
+$tx = $t->ua->build_tx(GET => "/api/v1/patrons/attributes?code=testcode");
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)->status_is(400);
+
+$tx = $t->ua->build_tx(GET => "/api/v1/patrons/attributes?attribute=testval");
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)->status_is(400);
+#
+
+## should return our test patron
+$tx = $t->ua->build_tx(GET => "/api/v1/patrons/attributes?code=testcode&attribute=testval");
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(200)
+    ->json_is('/0/borrowernumber' => $patron->{ borrowernumber });
+
+## should return empty array for non-existing attribute value
+$tx = $t->ua->build_tx(GET => "/api/v1/patrons/attributes?code=testcode&attribute=testva");
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(200)
+    ->content_is('[]');
+
+## should return empty array for non-existing attribute code
+$tx = $t->ua->build_tx(GET => "/api/v1/patrons/attributes?code=testcod&attribute=testval");
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(200)
+    ->content_is('[]');
+
+
+### POST /api/v1/patrons/attributes
+
+$patron_attribute_type = $builder->build({
+    source => 'BorrowerAttributeType',
+    value  => {
+        code      => "test_post",
+        unique_id => 0,
+        repeatable => 0
+    }
+});
+
+my $valid_post_data = {
+    borrowernumber => $patron->{borrowernumber},
+    code           => "test_post",
+    attribute          => "valid value"
+};
+
+## should require authentication
+$tx = $t->ua->build_tx(POST => "/api/v1/patrons/attributes" => json => $valid_post_data);
+$t->request_ok($tx)
+    ->status_is(401);
+
+## should require borrowers permission
+
+Koha::Auth::PermissionManager->revokeAllPermissions($librarian);
+
+$session = C4::Auth::get_session('');
+$session->param('number', $librarian->{ borrowernumber });
+$session->param('id', $librarian->{ userid });
+$session->param('ip', '127.0.0.1');
+$session->param('lasttime', time());
+$session->flush;
+
+$tx = $t->ua->build_tx(POST => "/api/v1/patrons/attributes" => json => $valid_post_data);
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(403)
+    ->json_is('/required_permissions', { "borrowers" => "*" });
+
+Koha::Auth::PermissionManager->grantAllSubpermissions(
+    $librarian->{borrowernumber}, 'borrowers'
+);
+
+## should require all fields
+$tx = $t->ua->build_tx(POST => "/api/v1/patrons/attributes" => json => {borrowernumber => $patron->{borrowernumber}});
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(400);
+
+$tx = $t->ua->build_tx(POST => "/api/v1/patrons/attributes" => json => {
+    borrowernumber => $patron->{borrowernumber},
+    code           => $valid_post_data->{code},
+});
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(400);
+
+## should return error for non-existing patrons
+my $invalid_post_data = {
+    borrowernumber => $patron->{borrowernumber} + 100,
+    code           => $valid_post_data->{code},
+    attribute          => $valid_post_data->{attribute}
+};
+
+$tx = $t->ua->build_tx(POST => "/api/v1/patrons/attributes" => json => $invalid_post_data);
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(500);
+
+## should return error for invalid attribute code
+$invalid_post_data->{borrowernumber} = $patron->{borrowernumber};
+$invalid_post_data->{code} = "non-existing-attribute-code";
+
+$tx = $t->ua->build_tx(POST => "/api/v1/patrons/attributes" => json => $invalid_post_data);
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(500);
+
+## should return 201 with the created attribute as body on success
+$tx = $t->ua->build_tx(POST => "/api/v1/patrons/attributes" => json => $valid_post_data);
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(201)
+    ->json_is('/borrowernumber', $valid_post_data->{borrowernumber})
+    ->json_is('/code', $valid_post_data->{code})
+    ->json_is('/attribute', $valid_post_data->{attribute});
+
+## should return 409 for non-repeatable code which already exists for patron
+$tx = $t->ua->build_tx(POST => "/api/v1/patrons/attributes" => json => $valid_post_data);
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(409)
+    ->json_like('/error' => qr/repeatable not set for attribute type/i);
+
+
+## should not allow adding multiple same values for unique type
+
+my $patron2 = $builder->build({
+    source => 'Borrower',
+    value  => {
+        branchcode    => $branchcode,
+        categorycode  => $categorycode,
+        flags         => 0,
+        lost          => 0,
+        gonenoaddress => 0,
+        password      => Koha::AuthUtils::hash_password($password),
+        email         => 'nobody@example.com',
+        emailpro      => 'nobody@example.com',
+        B_email       => 'nobody@example.com',
+    }
+});
+
+$builder->build({
+    source => 'BorrowerAttributeType',
+    value  => {
+        code      => "t_unique",
+        unique_id => 1,
+        repeatable => 0
+    }
+});
+
+# set unique_value for patron1, then try to add the same value for patron2
+Koha::Patron::Attribute->new({ borrowernumber => $patron->{borrowernumber}, code => "t_unique", attribute => 'unique_value' })
+    ->store();
+
+$valid_post_data->{code} = "t_unique";
+$valid_post_data->{borrowernumber} = $patron2->{borrowernumber};
+$valid_post_data->{attribute} = "unique_value";
+
+$tx = $t->ua->build_tx(POST => "/api/v1/patrons/attributes" => json => $valid_post_data);
+$tx->req->cookies({ name => 'CGISESSID', value => $session->id });
+$t->request_ok($tx)
+    ->status_is(409)
+    ->json_like('/error' => qr/unique_id set for attribute type/i);
+


### PR DESCRIPTION
two new REST API routes related to extended patron attributes

```
GET /patrons/attributes?code=attrkey&attribute=attrvalue
   - list/search for patrons by extended patron attribute code and value
POST /patrons/attributes  {"code": "attrkey", "attribute": "attrvalue", "borrowernumber":100}
   - add extended patron attribute for a patron
```

```prove t/db_dependent/api/v1/patronsattributes.t```