### PR TITLE
Bug 24185: Make holds page fast when 'on shelf holds' set to 'If all unavailable'

### DIFF
--- a/C4/Reserves.pm
+++ b/C4/Reserves.pm
@@ -1406,6 +1406,9 @@ and canreservefromotherbranches.
 sub IsAvailableForItemLevelRequest {
     my $item = shift;
     my $borrower = shift;
+    # items_any_available is precalculated status passed from request.pl when set of items
+    # looped outside of IsAvailableForItemLevelRequest to avoid nested loops:
+    my $items_any_available = shift;
 
     my $dbh = C4::Context->dbh;
     # must check the notforloan setting of the itemtype
@@ -1432,6 +1435,12 @@ sub IsAvailableForItemLevelRequest {
     if ( $on_shelf_holds == 1 ) {
         return 1;
     } elsif ( $on_shelf_holds == 2 ) {
+
+        # if we have this param predefined from outer caller sub, we just need
+        # to return it, so we saving from having loop inside other loop:
+        return $items_any_available ? 0 : 1
+            if defined $items_any_available;
+
         my @items =
           Koha::Items->search( { biblionumber => $item->{biblionumber} } );
 

--- a/reserve/request.pl
+++ b/reserve/request.pl
@@ -470,8 +470,8 @@ foreach my $biblionumber (@biblionumbers) {
                 if (
                        !$item->{cantreserve}
                     && !$exceeded_maxreserves
-                    && IsAvailableForItemLevelRequest($item, $borrowerinfo)
                     && $can_item_be_reserved eq 'OK'
+                    && IsAvailableForItemLevelRequest($item, $borrowerinfo)
                   )
                 {
                     $item->{available} = 1;

--- a/reserve/request.pl
+++ b/reserve/request.pl
@@ -217,61 +217,63 @@ foreach my $biblionumber (@biblionumbers) {
 
     my $dat = GetBiblioData($biblionumber);
 
-    my $canReserve = CanBookBeReserved( $borrowerinfo->{borrowernumber}, $biblionumber );
-    $canReserve //= '';
-    if ( $canReserve eq 'OK' ) {
-
-        #All is OK and we can continue
-    }
-    elsif ( $canReserve eq 'tooManyReserves' ) {
-        $exceeded_maxreserves = 1;
-    }
-    elsif ( $canReserve eq 'tooManyHoldsForThisRecord' ) {
-        $exceeded_holds_per_record = 1;
-        $biblioloopiter{$canReserve} = 1;
-    }
-    elsif ( $canReserve eq 'ageRestricted' ) {
-        $template->param( $canReserve => 1 );
-        $biblioloopiter{$canReserve} = 1;
-    }
-    else {
-        $biblioloopiter{$canReserve} = 1;
-    }
-
     my $force_hold_level;
-    if ( $borrowerinfo->{borrowernumber} ) {
-        # For multiple holds per record, if a patron has previously placed a hold,
-        # the patron can only place more holds of the same type. That is, if the
-        # patron placed a record level hold, all the holds the patron places must
-        # be record level. If the patron placed an item level hold, all holds
-        # the patron places must be item level
-        my $holds = Koha::Holds->search(
-            {
-                borrowernumber => $borrowerinfo->{borrowernumber},
-                biblionumber   => $biblionumber,
-                found          => undef,
-            }
-        );
-        $force_hold_level = $holds->forced_hold_level();
-        $biblioloopiter{force_hold_level} = $force_hold_level;
-        $template->param( force_hold_level => $force_hold_level );
+    if ( $borrowerinfo ) {
+        my $canReserve = CanBookBeReserved( $borrowerinfo->{borrowernumber}, $biblionumber );
+        $canReserve //= '';
+        if ( $canReserve eq 'OK' ) {
 
-        # For a librarian to be able to place multiple record holds for a patron for a record,
-        # we must find out what the maximum number of holds they can place for the patron is
-        my $max_holds_for_record = GetMaxPatronHoldsForRecord( $borrowerinfo->{borrowernumber}, $biblionumber );
-        my $remaining_holds_for_record = $max_holds_for_record - $holds->count();
-        $biblioloopiter{remaining_holds_for_record} = $max_holds_for_record;
-        $template->param( max_holds_for_record => $max_holds_for_record );
-        $template->param( remaining_holds_for_record => $remaining_holds_for_record );
-    }
+            #All is OK and we can continue
+        }
+        elsif ( $canReserve eq 'tooManyReserves' ) {
+            $exceeded_maxreserves = 1;
+        }
+        elsif ( $canReserve eq 'tooManyHoldsForThisRecord' ) {
+            $exceeded_holds_per_record = 1;
+            $biblioloopiter{$canReserve} = 1;
+        }
+        elsif ( $canReserve eq 'ageRestricted' ) {
+            $template->param( $canReserve => 1 );
+            $biblioloopiter{$canReserve} = 1;
+        }
+        else {
+            $biblioloopiter{$canReserve} = 1;
+        }
 
-    # Check to see if patron is allowed to place holds on records where the
-    # patron already has an item from that record checked out
-    my $alreadypossession;
-    if ( !C4::Context->preference('AllowHoldsOnPatronsPossessions')
-        && CheckIfIssuedToPatron( $borrowerinfo->{borrowernumber}, $biblionumber ) )
-    {
-        $template->param( alreadypossession => $alreadypossession, );
+        if ( $borrowerinfo->{borrowernumber} ) {
+            # For multiple holds per record, if a patron has previously placed a hold,
+            # the patron can only place more holds of the same type. That is, if the
+            # patron placed a record level hold, all the holds the patron places must
+            # be record level. If the patron placed an item level hold, all holds
+            # the patron places must be item level
+            my $holds = Koha::Holds->search(
+                {
+                    borrowernumber => $borrowerinfo->{borrowernumber},
+                    biblionumber   => $biblionumber,
+                    found          => undef,
+                }
+            );
+            $force_hold_level = $holds->forced_hold_level();
+            $biblioloopiter{force_hold_level} = $force_hold_level;
+            $template->param( force_hold_level => $force_hold_level );
+
+            # For a librarian to be able to place multiple record holds for a patron for a record,
+            # we must find out what the maximum number of holds they can place for the patron is
+            my $max_holds_for_record = GetMaxPatronHoldsForRecord( $borrowerinfo->{borrowernumber}, $biblionumber );
+            my $remaining_holds_for_record = $max_holds_for_record - $holds->count();
+            $biblioloopiter{remaining_holds_for_record} = $max_holds_for_record;
+            $template->param( max_holds_for_record => $max_holds_for_record );
+            $template->param( remaining_holds_for_record => $remaining_holds_for_record );
+        }
+
+        # Check to see if patron is allowed to place holds on records where the
+        # patron already has an item from that record checked out
+        my $alreadypossession;
+        if ( !C4::Context->preference('AllowHoldsOnPatronsPossessions')
+            && CheckIfIssuedToPatron( $borrowerinfo->{borrowernumber}, $biblionumber ) )
+        {
+            $template->param( alreadypossession => $alreadypossession, );
+        }
     }
 
 
@@ -453,40 +455,42 @@ foreach my $biblionumber (@biblionumbers) {
                 }
             }
 
-            my $branch = C4::Circulation::_GetCircControlBranch($item, $borrowerinfo);
+            if ( $borrowerinfo ) {
+                my $branch = C4::Circulation::_GetCircControlBranch($item, $borrowerinfo);
 
-            my $branchitemrule = GetBranchItemRule( $branch, $item->{'itype'} );
+                my $branchitemrule = GetBranchItemRule( $branch, $item->{'itype'} );
 
-            $item->{'holdallowed'} = $branchitemrule->{'holdallowed'};
+                $item->{'holdallowed'} = $branchitemrule->{'holdallowed'};
 
-            my $can_item_be_reserved = CanItemBeReserved( $borrowerinfo->{borrowernumber}, $itemnumber );
-            $item->{not_holdable} = $can_item_be_reserved unless ( $can_item_be_reserved eq 'OK' );
+                my $can_item_be_reserved = CanItemBeReserved( $borrowerinfo->{borrowernumber}, $itemnumber );
+                $item->{not_holdable} = $can_item_be_reserved unless ( $can_item_be_reserved eq 'OK' );
 
-            $item->{item_level_holds} = OPACItemHoldsAllowed( $item, $borrowerinfo );
+                $item->{item_level_holds} = OPACItemHoldsAllowed( $item, $borrowerinfo );
 
-            if (
-                   !$item->{cantreserve}
-                && !$exceeded_maxreserves
-                && IsAvailableForItemLevelRequest($item, $borrowerinfo)
-                && $can_item_be_reserved eq 'OK'
-              )
-            {
-                $item->{available} = 1;
-                $num_available++;
+                if (
+                       !$item->{cantreserve}
+                    && !$exceeded_maxreserves
+                    && IsAvailableForItemLevelRequest($item, $borrowerinfo)
+                    && $can_item_be_reserved eq 'OK'
+                  )
+                {
+                    $item->{available} = 1;
+                    $num_available++;
 
-                push( @available_itemtypes, $item->{itype} );
-            }
-            elsif ( C4::Context->preference('AllowHoldPolicyOverride') ) {
-                # If AllowHoldPolicyOverride is set, it should override EVERY restriction, not just branch item rules
-                $item->{override} = 1;
-                $num_override++;
-            }
+                    push( @available_itemtypes, $item->{itype} );
+                }
+                elsif ( C4::Context->preference('AllowHoldPolicyOverride') ) {
+                    # If AllowHoldPolicyOverride is set, it should override EVERY restriction, not just branch item rules
+                    $item->{override} = 1;
+                    $num_override++;
+                }
 
-            # If none of the conditions hold true, then neither override nor available is set and the item cannot be checked
+                # If none of the conditions hold true, then neither override nor available is set and the item cannot be checked
 
-            # Show serial enumeration when needed
-            if ($item->{enumchron}) {
-                $itemdata_enumchron = 1;
+                # Show serial enumeration when needed
+                if ($item->{enumchron}) {
+                    $itemdata_enumchron = 1;
+                }
             }
 
             push @{ $biblioitem->{itemloop} }, $item;


### PR DESCRIPTION
+ Two smaller optimizations in separate commits.

Main commit fix:

When "reserve/request.pl -> C4/Reserves.pm::IsAvailableForItemLevelRequest" called many times with hundred of items and "on shelf holds" parameter set to "If all unavailable" for these items + patron, it goes slow.

It happens because in subloop there is checking if all items available so it is O(n^2) and it re-checks each time the same info for each item with repeating DB/data requests.

Fix:
The inner loop 1:1 picked out from another loop and put before that items processing loop,
'items_any_available' variable precalculated,
this variable passed to IsAvailableForItemLevelRequest to be used inside as the precalculated result.
On tests it gave a drastic improvement in execution time.

How to reproduce:

1) on freshly installed kohadevbox create/import one book,
remember that biblionumber for later use it in down below,

2) add 100 items for that book for some library,

3) find some patron, that patron's card number we will
use as a borrower down below to open holds page,

4) check for the rule or set up a single circulation rule
in admin "/cgi-bin/koha/admin/smart-rules.pl",
that rule should match above book items/library/patron,
check that rule to have a non-zero number of holds (total, daily, count) allowed,
and, IMPORTANT: set up "On shelf holds allowed" to "If all unavailable",
("item level holds" doesn't matter).

5) open "Home > Catalog > THAT_BOOK > Place a hold on THAT_BOOK" page
("holds" tab), and enter patron code in the search field,
or you can create a direct link by yourself, for example, in my case it was:
/cgi-bin/koha/reserve/request.pl?biblionumber=4&findborrower=23529000686353

6) it should be pretty long page generation time on old code, densely increasing for every hundred items added. In the case of this solution, it's fast, and time increases a little only, linear.

I tested on my computer in VirtualBox for page generation times,
did 3-5 runs for the same case to check if results are stable, and got such values:

(old code):
  100 items:    25 seconds
  200 items:   1.6 minutes
  300 items:   3.5 minutes

(version with fix):
  100 items:   3.5 seconds
  200 items:   5.1 seconds
  300 items:   7.9 seconds