### PR TITLE
Bug 2520: (squashable) Fix syntax error

### DIFF
--- a/C4/Reserves.pm
+++ b/C4/Reserves.pm
@@ -1827,7 +1827,6 @@ sub _Findgroupreserve {
             if ($checked) {
                 push( @results, $data )
                     unless any{ $data->{borrowernumber} eq $_ } @$ignore_borrowers ;
-                last;
             }
         } else {
             push( @results, $data )
@@ -1872,7 +1871,6 @@ sub _Findgroupreserve {
             if ($checked) {
                 push( @results, $data )
                     unless any{ $data->{borrowernumber} eq $_ } @$ignore_borrowers ;
-                last;
             }
         } else {
             push( @results, $data )


### PR DESCRIPTION
If condition doesn't need last statement. The last statements were
probably added mistakenly because there was another while loop with
similar code where last statement is good to have for performance
reasons.