### PR TITLE
Bug 24185: Make holds page fast when 'on shelf holds' set to 'If all unavailable'

### DIFF
--- a/C4/Reserves.pm
+++ b/C4/Reserves.pm
@@ -1405,8 +1405,11 @@ and canreservefromotherbranches.
 =cut
 
 sub IsAvailableForItemLevelRequest {
-    my $item = shift;
-    my $borrower = shift;
+    my $item                = shift;
+    my $borrower            = shift;
+    # items_any_available is precalculated status passed from request.pl when set of items
+    # looped outside of IsAvailableForItemLevelRequest to avoid nested loops:
+    my $items_any_available = shift;
 
     my $dbh = C4::Context->dbh;
     # must check the notforloan setting of the itemtype
@@ -1433,6 +1436,12 @@ sub IsAvailableForItemLevelRequest {
     if ( $on_shelf_holds == 1 ) {
         return 1;
     } elsif ( $on_shelf_holds == 2 ) {
+
+        # if we have this param predefined from outer caller sub, we just need
+        # to return it, so we saving from having loop inside other loop:
+        return  $items_any_available ? 0 : 1
+            if defined $items_any_available;
+
         my $any_available = ItemsAnyAvailableForHold( { biblionumber => $item->{biblionumber} });
         return $any_available ? 0 : 1;
     }

--- a/reserve/request.pl
+++ b/reserve/request.pl
@@ -469,8 +469,8 @@ foreach my $biblionumber (@biblionumbers) {
                 if (
                        !$item->{cantreserve}
                     && !$exceeded_maxreserves
-                    && IsAvailableForItemLevelRequest($item, $borrowerinfo)
                     && $can_item_be_reserved eq 'OK'
+                    && IsAvailableForItemLevelRequest($item, $borrowerinfo)
                   )
                 {
                     $item->{available} = 1;

--- a/t/db_dependent/Holds/DisallowHoldIfItemsAvailable.t
+++ b/t/db_dependent/Holds/DisallowHoldIfItemsAvailable.t
@@ -7,7 +7,7 @@ use C4::Items;
 use C4::Circulation;
 use Koha::IssuingRule;
 
-use Test::More tests => 4;
+use Test::More tests => 7;
 
 use t::lib::TestBuilder;
 
@@ -101,15 +101,26 @@ my $rule = Koha::IssuingRule->new(
 );
 $rule->store();
 
-my $is = IsAvailableForItemLevelRequest( $item1, $borrower1);
+my $is;
+
+$is = ItemsAnyAvailableForHold( { biblionumber => $biblionumber });
+is( $is, 1, "Items availability: both of 2 items are available" );
+
+$is = IsAvailableForItemLevelRequest( $item1, $borrower1);
 is( $is, 0, "Item cannot be held, 2 items available" );
 
 AddIssue( $borrower2, $item1->{barcode} );
+
+$is = ItemsAnyAvailableForHold( { biblionumber => $biblionumber });
+is( $is, 1, "Items availability: one item is available" );
 
 $is = IsAvailableForItemLevelRequest( $item1, $borrower1);
 is( $is, 0, "Item cannot be held, 1 item available" );
 
 AddIssue( $borrower2, $item2->{barcode} );
+
+$is = ItemsAnyAvailableForHold( { biblionumber => $biblionumber });
+is( $is, 0, "Items availability: none of items are available" );
 
 $is = IsAvailableForItemLevelRequest( $item1, $borrower1);
 is( $is, 1, "Item can be held, no items available" );


### PR DESCRIPTION
Few preparatory commits:
- check for defined "borrowerinfo" for not to run extra code
- "if" block optimization first to analyze already precomputed values
- and refactor to have separate subroutine "ItemsAnyAvailableForHold " in Reserves.pm + test update.

**Then that subroutine and test used in the last from the commits to make a fix:**

When "reserve/request.pl -> C4/Reserves.pm::IsAvailableForItemLevelRequest" called many times with hundred of items and "on shelf holds" parameter set to "If all unavailable" for these items + patron, it goes slow.

It happens because in subloop it is checking if all items available so it is O(n^2) and it re-checks each time the same info for each item with repeating DB/data requests.

Fix:
The inner loop 1:1 picked out into separate subroutine and called outside of the loop, saving data in 'items_any_available' variable once, this variable passed to IsAvailableForItemLevelRequest to be used inside as the precalculated result.

This made algorithm O(n) instead of O(n^2) so there is noticeable speed increase.

How to reproduce:

1) on freshly installed kohadevbox create/import one book,
remember that biblionumber for later use it in down below,

2) add 100 items for that book for some library,

3) find some patron, that patron's card number we will
use as a borrower down below to open holds page,

4) check for the rule or set up a single circulation rule
in admin "/cgi-bin/koha/admin/smart-rules.pl",
that rule should match above book items/library/patron,
check that rule to have a non-zero number of holds (total, daily, count) allowed,
and, IMPORTANT: set up "On shelf holds allowed" to "If all unavailable",
("item level holds" doesn't matter).

5) open "Home > Catalog > THAT_BOOK > Place a hold on THAT_BOOK" page
("holds" tab), and enter patron code in the search field,
or you can create a direct link by yourself, for example, in my case it was:
/cgi-bin/koha/reserve/request.pl?biblionumber=4&findborrower=23529000686353

6) it should be pretty long page generation time on old code, densely increasing for every hundred items added. In the case of this solution, it's fast, and time increases a little only, linear.

I tested on my computer in VirtualBox for page generation times,
did 3-5 runs for the same case to check if results are stable, and got such values:

(old code):
  100 items:  26.7 seconds
  200 items:   1.7 minutes
  300 items:   3.6 minutes

(version with fix):
  100 items:   4.3 seconds
  200 items:   6.7 seconds
  300 items:   9.6 seconds