### PR TITLE
Bug 13193: Make Memcached usage fork safe

### DIFF
--- a/C4/Installer/PerlDependencies.pm
+++ b/C4/Installer/PerlDependencies.pm
@@ -345,7 +345,12 @@ our $PERL_DEPS = {
     'Cache::Memcached::Fast' => {
         'usage'    => 'Caching',
         'required' => '0',
-        'min_ver'  => '0.17'
+        'min_ver'  => '0.19'
+    },
+    'Cache::Memcached::Fast::Safe' => {
+        'usage'    => 'Caching',
+        'required' => '0',
+        'min_ver'  => '0.06'
     },
     'Cache::FastMmap' => {
         'usage'    => 'Caching',

--- a/Koha/Cache.pm
+++ b/Koha/Cache.pm
@@ -87,7 +87,7 @@ sub new {
     $self->{namespace} .= ":$subnamespace:";
 
     if ( $self->{'default_type'} eq 'memcached'
-        && can_load( modules => { 'Cache::Memcached::Fast' => undef } )
+        && can_load( modules => { 'Cache::Memcached::Fast::Safe' => undef } )
         && _initialize_memcached($self, @servers)
         && defined( $self->{'memcached_cache'} ) )
     {
@@ -129,9 +129,9 @@ sub _initialize_memcached {
       . join( ', ', @servers )
       . " with "
       . $self->{'namespace'};
-    # Cache::Memcached::Fast doesn't allow a default expire time to be set
+    # Cache::Memcached::Fast::Safe doesn't allow a default expire time to be set
     # so we force it on setting.
-    my $memcached = Cache::Memcached::Fast->new(
+    my $memcached = Cache::Memcached::Fast::Safe->new(
         {
             servers            => \@servers,
             compress_threshold => 10_000,

--- a/koha-tmpl/intranet-tmpl/prog/en/modules/about.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/about.tt
@@ -73,7 +73,7 @@
                         [% CASE # nowhere %]
                             <span class="status_warn">Nowhere</span> Note that the right place to define the memcached config is in your $KOHA_CONF file. Currently you do not have a valid memcached configuration defined.
                     [% END %]
-                  [% IF effective_caching_method != 'Cache::Memcached::Fast' %]
+                  [% IF effective_caching_method != 'Cache::Memcached::Fast::Safe' %]
                     | Effective caching method: [% effective_caching_method %]
                   [% END %]
                 </td>


### PR DESCRIPTION
When a high enough number of forks try to access for example system
preferences with Koha::Cache using memcached as backend the results of
different cache requests get mixed up.

The problem is fixed by using Cache::Memcached::Fast::Safe that is a
fork safe version of Cache::Memcached::Fast.

Sponsored-by: The National Library of Finland
Signed-off-by: David Cook <dcook@prosentient.com.au>

Works as described, and solves an insidious difficult to debug
problem in Koha.