### PR TITLE
KD-4302: (squashme) Don't delete holdings records with safe option

### DIFF
--- a/Koha/REST/V1/Biblio.pm
+++ b/Koha/REST/V1/Biblio.pm
@@ -245,6 +245,7 @@ sub update {
 
 sub delete {
     my $c = shift->openapi->valid_input or return;
+    my $res;
 
     my $biblio = Koha::Biblios->find($c->validation->param('biblionumber'));
     unless ($biblio) {
@@ -267,9 +268,15 @@ sub delete {
         foreach my $holding (@holdings) {
             $holding->delete;
         }
+        $res = C4::Biblio::DelBiblio($biblio->biblionumber, 1);
+    } else {
+        if ($biblio->holdings->count) {
+            $res = "This Biblio has holdings records attached, please delete them first before deleting this biblio";
+        } else {
+            $res = C4::Biblio::DelBiblio($biblio->biblionumber, 1);
+        }
     }
 
-    my $res = C4::Biblio::DelBiblio($biblio->biblionumber, 1);
 
     unless ($res) {
         return $c->render(status => 200, openapi => {});


### PR DESCRIPTION
The safe option only worked earlier for items even though it was meant
to disallow deletion of holdings records too.