### PR TITLE
Bug 20535: ModZebra called with $record with items stripped

### DIFF
--- a/C4/Biblio.pm
+++ b/C4/Biblio.pm
@@ -4216,7 +4216,7 @@ sub ModBiblioMarc {
         $m_rs->metadata( $record->as_xml_record($encoding) );
         $m_rs->store;
     }
-    ModZebra( $biblionumber, "specialUpdate", "biblioserver", $record );
+    ModZebra( $biblionumber, "specialUpdate", "biblioserver" );
     return $biblionumber;
 }
 


### PR DESCRIPTION
ModZebra called with $record with items stripped in
ModBiblioMarc. Remove $record argument to force
record to be loaded again from database with items
embedded.

How to test:
1) Make sure biblios are indexed (with
   rebuild_elastic_search.pl).
2) Perform a search that will produce a sample result
   containing at least one biblio with items.
3) Edit and save a biblio with items.
4) Perform the same search again, the updated biblio
   should now have no items when viewed in the search
   results (No items).
5) Apply patch.
6) Repeat step 1-3.
7) The updated biblio should now have items when viewed
   in the search results.

Signed-off-by: Josef Moravec <josef.moravec@gmail.com>

Signed-off-by: Kyle M Hall <kyle@bywatersolutions.com>

Signed-off-by: Nick Clemens <nick@bywatersolutions.com>