### PR TITLE
Set dry mode as default for Ropocapital print provider

### DIFF
--- a/etc/koha-conf.xml
+++ b/etc/koha-conf.xml
@@ -323,11 +323,11 @@ __PAZPAR2_TOGGLE_XML_POST__
       <customerPass></customerPass> <!-- Opus Capita customer password -->
     </opusFTP>
     <ropocapital>
-      <!-- <dontReallySendAnything>comment this to actually send the letters, now we are just fakin'</dontReallySendAnything> -->
+      <dontReallySendAnything>comment this to actually send the letters, now we are just fakin'</dontReallySendAnything>
       <letterStagingDirectory>/tmp/ropocapital/</letterStagingDirectory>
-      <clientId>JNS190</clientId>
+      <clientId></clientId>
       <!-- <remoteDirectory>Enfo doesnt want us to specify a root-directory</remoteDirectory>-->
-      <host>zmartgate.enfo.fi</host>
+      <host>HOSTNAME</host>
       <user>USERNAME</user>
       <passwd>PASSWORD</passwd>
       <sftp>1</sftp>

--- a/misc/cronjobs/overduemessages.pl
+++ b/misc/cronjobs/overduemessages.pl
@@ -124,7 +124,7 @@ EXAMPLES:
   <ropocapital>
    <!-- <dontReallySendAnything>comment this to actually send the letters, now we are just fakin'</dontReallySendAnything> -->
    <letterStagingDirectory>/tmp/ropocapital/</letterStagingDirectory>
-   <clientId>JNS190</clientId>
+   <clientId>CLIENTID</clientId>
    <remoteDirectory>testedtester</remoteDirectory>
    <host>ROPO IP</host>
    <user>USERNAME</user>


### PR DESCRIPTION
This is for new installations.

Dry-mode was disabled in KOHA_CONF and if overduemessages.pl were to be
executed, it would had made a request to Ropocapital server with invalid
logins.

Additionally, remove client id from the configuration. It is not
sensitive data but it should definitely not be there.

Also removes the real hostname. Let sysadmins configure it.