### PR TITLE
KD-4530: Cronjob for setting expirationdate for holds

### DIFF
--- a/misc/cronjobs/holds/set_expirationdate_for_holds.pl
+++ b/misc/cronjobs/holds/set_expirationdate_for_holds.pl
@@ -1,0 +1,71 @@
+#!/usr/bin/perl
+
+# This file is part of Koha.
+#
+# Koha is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+#
+# Koha is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Koha; if not, see <http://www.gnu.org/licenses>.
+
+use strict;
+use warnings;
+
+use Modern::Perl;
+
+use Getopt::Long;
+
+use Koha::Database;
+use Koha::DateUtils qw( dt_from_string );
+use Koha::Holds;
+
+my ( $help, $confirm );
+
+GetOptions(
+    'h|help'        => \$help,
+    'c|confirm'     => \$confirm,
+);
+
+my $usage = << 'ENDUSAGE';
+
+This script updates holds expiration date if none exists.
+Expiration date will be set 2 years from the reserve date.
+
+This script has the following parameters :
+    -h --help: this message help message
+    -c --confirm: run update (without this just number of holds
+    to update is printed.)
+
+ENDUSAGE
+
+if ($help) {
+    print $usage;
+    exit;
+}
+
+my $dt = Koha::Database->new->schema->storage->datetime_parser;
+
+my $holds = Koha::Holds->search({
+    expirationdate => undef,
+});
+
+say "Found ". $holds->count ." hold(s) without expiration date.";
+
+unless ($confirm) {
+    say "Run again with -c or --confirm to update holds.";
+}
+
+if($confirm){
+    while (my $hold = $holds->next){
+        my $reservedate = $hold->reservedate;
+        my $expirationdate = $dt->format_date(dt_from_string($reservedate)->add( years => 2 ));
+        $hold->set({ expirationdate => $expirationdate })->store();
+    }
+}


### PR DESCRIPTION
Holds made in Koha staff client don't automatically have
expiration date set (in Finna this date is set 2 years
into the future).

This patch adds new cronjob to set and update expiration
date 2 years from holds reserve date. Only holds without
expiration date are affected.

To test:

1. Have some holds without expiration date.
2. Run misc/cronjobs/holds/set_expirationdate_for_holds.pl -c
3. Confirm holds now have expiration date (2 years from reservation
date).