### PR TITLE
KD-4641: Missing end tag on memberentrygen.tt

### DIFF
--- a/koha-tmpl/intranet-tmpl/prog/en/modules/members/memberentrygen.tt
+++ b/koha-tmpl/intranet-tmpl/prog/en/modules/members/memberentrygen.tt
@@ -1036,9 +1036,10 @@ $(document).ready(function() {
 			[% END %]
 	  [% IF ( mandatorypassword ) %]<span class="required">Required</span>[% END %][% IF ( ERROR_password_mismatch ) %]<span class="required">Passwords do not match</span>[% END %]
 		</li>
+        [% END %]
 		</ol>
 		</fieldset>
-        [% END # hide fieldset %][% END %]
+        [% END # hide fieldset %]
 		<!--this zones are not necessary in modif mode -->
         [% UNLESS ( opadd || opduplicate ) %]
         <fieldset class="rows" id="memberentry_account_flags">


### PR DESCRIPTION
Adding 'password' to 'BorrowerUnwantedField' makes
unintended changes to patron form due missing
[% END %] tag on memberentrygen.tt.

To test:
1. Add 'password' to 'BorrowerUnwantedField'.
2. Edit patron, note after 'OPAC/Staff login' forms
structure is broken.
3. Apply this patch.
4. Confirm form is now displayed correctly.