### PR TITLE
KD-4838: Add --user when pidfile is used

### DIFF
--- a/debian/scripts/koha-functions.sh
+++ b/debian/scripts/koha-functions.sh
@@ -209,6 +209,7 @@ is_plack_running()
     local instancename=$1
 
     if start-stop-daemon --pidfile "/var/run/koha/${instancename}/plack.pid" \
+            --user=$DAEMON_USER \
             --status ; then
         return 0
     else

--- a/debian/scripts/koha-plack
+++ b/debian/scripts/koha-plack
@@ -113,7 +113,7 @@ stop_plack()
 
         log_daemon_msg "Stopping Plack daemon for ${instancename}"
 
-        if start-stop-daemon --pidfile ${PIDFILE} --stop --retry=TERM/30/KILL/5; then
+        if start-stop-daemon --pidfile ${PIDFILE} --user=$DAEMON_USER --stop --retry=TERM/30/KILL/5; then
             log_end_msg 0
         else
             log_end_msg 1


### PR DESCRIPTION
in koha-plack-daemon

Since D10 start-stop-daemon changed its behaviour. From
start-stop-daemon manual:

"Warning: using this match option with a world-writable
pidfile or using it alone with a daemon that writes the
pidfile as an unprivileged (non-root) user will be refused
with an error (since version 1.19.3) as this is a security
risk, because either any user can write to it, or if the
daemon gets compromised, the contents of the pidfile
cannot be trusted, and then a privileged runner (such as
an init script executed as root) would end up acting on
any system process. Using /dev/null is exempt from these
checks."

This is fixed in community version with bug 25481.